### PR TITLE
treat args with the same name (but in different subparsers) as different values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versions follow [Semantic Versioning](https://semver.org) (`<major>.<minor>.<pat
 
 - build parser based on function arguments
 - build parser with sub-commands using multiple functions
+- add constructor parameter for options
 
 
 ## 0.0.11

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # argser
 
 [![PyPI version](https://badge.fury.io/py/argser.svg)](http://badge.fury.io/py/argser)
+[![Downloads](https://pepy.tech/badge/argser)](https://pepy.tech/project/argser)
 [![Build Status](https://github.com/vanyakosmos/argser/workflows/test-publish/badge.svg)](https://github.com/vanyakosmos/argser/actions?workflow=test-publish)
 [![Coverage](https://codecov.io/gh/vanyakosmos/argser/branch/master/graph/badge.svg)](https://codecov.io/gh/vanyakosmos/argser)
-[![License](https://img.shields.io/github/license/mashape/apistatus.svg)](https://pypi.python.org/pypi/argser/)
-[![Downloads](https://pepy.tech/badge/argser)](https://pepy.tech/project/argser)
+[![Docs](https://readthedocs.org/projects/argser/badge/?version=stable)](https://argser.readthedocs.io/en/stable/)
 
 [GitHub](https://github.com/vanyakosmos/argser) | 
 [PyPI](https://pypi.org/project/argser/) | 
-[Docs](https://argser.readthedocs.io/en/latest) | 
-[Examples](https://argser.readthedocs.io/en/latest/examples.html) | 
+[Docs](https://argser.readthedocs.io/en/stable) | 
+[Examples](https://argser.readthedocs.io/en/stable/examples.html) | 
+[Installation](https://argser.readthedocs.io/en/stable/installation.html) | 
 [Changelog](CHANGELOG.md)
 
 Arguments parsing without boilerplate.
@@ -44,7 +45,7 @@ class Args:
     a = 'a'
     foo = 1
     bar: bool
-
+    bar_baz = 42, "bar_baz help"
 
 args = parse_args(Args, show=True)
 ```
@@ -61,6 +62,7 @@ parser.add_argument('--foo', '-f', dest='foo', type=int, default=1, help="int, d
 parser.add_argument('--bar', '-b', dest='bar', action='store_true', help="bool, default: None")
 parser.add_argument('--no-bar', '--no-b', dest='bar', action='store_false')
 parser.set_defaults(bar=None)
+parser.add_argument('--bar-baz', dest='bar_baz', default=42, help="int, default: 42. bar_baz help")
 
 args = parser.parse_args()
 print(args)
@@ -69,20 +71,20 @@ print(args)
 
 ```text
 ❯ python playground.py -a "aaa bbb" -f 100500 --no-b
->> Args(bar=False, a='aaa bbb', foo=100500)
+>>> Args(bar=False, a='aaa bbb', foo=100500, bar_baz=42)
 ```
 
 ```text
 ❯ python playground.py -h
-usage: playground.py [-h] [--bar] [--no-bar] [-a [A]] [--foo [FOO]]
+usage: playground.py [-h] [--bar] [--no-bar] [-a A] [--foo F] [--bar-baz B]
 
 optional arguments:
-  -h, --help            show this help message and exit
-  --bar, -b             bool, default: None.
-  --no-bar, --no-b
-  -a [A]                str, default: 'a'.
-  --foo [FOO], -f [FOO]
-                        int, default: 1.
+    -h, --help           show this help message and exit
+    --bar, -b            bool, default: None
+    --no-bar, --no-b
+    -a A                 str, default: 'a'
+    --foo F, -f F        int, default: 1
+    --bar-baz B, --bb B  int, default: 42. bar_baz help
 ```
 
 
@@ -102,19 +104,20 @@ assert argser.call(foo, '1 2 -c 3.4') == ['1', 2, 3.4]
 
 ```python
 from argser import parse_args, sub_command
-    
-class SubArgs:
-    d = 1
-    e = '2'
 
 class Args:
     a: bool
     b = []
     c = 5
+    
+    class SubArgs:
+        d = 1
+        e = '2'
     sub = sub_command(SubArgs, help='help message for sub-command')
 
-args = parse_args(Args, '-a -c 10', parser_help='help message for root parser')
+args = parse_args(Args, '-a -b a b -c 10', parser_help='help message for root parser')
 assert args.a is True
+assert args.b == ['a', 'b']
 assert args.c == 10
 assert args.sub is None
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ pip install argser[all]
 ```
 
 
+## Notes for examples
+
+If second parameter of `parse_args` is string (as in almost all examples) then it will be parsed,
+otherwise arguments to parse will be taken from command line.
+
+
 ## Simple example
 
 ```python

--- a/argser/__init__.py
+++ b/argser/__init__.py
@@ -1,7 +1,7 @@
 __version__ = "0.0.11"
 
 from argser.consts import FALSE_VALUES, TRUE_VALUES
-from argser.display import make_table, stringify
+from argser.display import stringify, print_args
 from argser.fields import Arg, Opt
 from argser.parse_func import SubCommands, call
 from argser.parser import make_parser, parse_args, populate_holder, sub_command

--- a/argser/consts.py
+++ b/argser/consts.py
@@ -5,4 +5,3 @@ Args = TypeVar('Args')
 TRUE_VALUES = {'1', 'true', 't', 'okay', 'ok', 'affirmative', 'yes', 'y', 'totally'}
 FALSE_VALUES = {'0', 'false', 'f', 'no', 'n', 'nope', 'nah'}
 SUB_COMMAND_MARK = '__sub_command'
-SUB_COMMAND_DEST_FMT = '__{name}_sub_command__'

--- a/argser/display.py
+++ b/argser/display.py
@@ -12,8 +12,8 @@ def stringify(args: Args, shorten=False):
     def pair(x):
         k, v = x
         if shorten:
-            v = repr(v)
-            v = textwrap.shorten(v, width=20, placeholder='...')
+            v = textwrap.shorten(str(v), width=20, placeholder='...')
+        v = repr(v)
         return f"{k}={v}"
 
     pairs = ', '.join(map(pair, args.__dict__.items()))
@@ -27,9 +27,9 @@ def stringify_colored(args: Args, shorten=False):
         if v is None:
             v = colors.red('-')
         else:
-            v = repr(v)
             if shorten:
-                v = textwrap.shorten(v, width=20, placeholder='...')
+                v = textwrap.shorten(str(v), width=20, placeholder='...')
+            v = repr(v)
         return f"{colors.green(k)}={v}"
 
     pairs = ', '.join(map(pair, args.__dict__.items()))
@@ -148,8 +148,8 @@ def print_args(args: Args, variant=None, print_fn=None, colorize=True, shorten=F
 
     :param args: some object with attributes
     :param variant:
-        if truthy value - print arguments in one line
         if 'table' - print arguments as table
+        otherwise print arguments in one line
     :param print_fn:
     :param colorize: add colors to the help message and arguments printing
     :param shorten: shorten long text (eg long default value)
@@ -161,9 +161,7 @@ def print_args(args: Args, variant=None, print_fn=None, colorize=True, shorten=F
     if variant == 'table':
         s = make_table(args, colorize=colorize, shorten=shorten, **kwargs)
     else:
-        if colorize:
-            s = stringify_colored(args, shorten)
-        else:
-            s = stringify(args, shorten)
+        to_str = stringify_colored if colorize else stringify
+        s = to_str(args, shorten)
     print_fn = print_fn or print
     print_fn(s)

--- a/argser/fields.py
+++ b/argser/fields.py
@@ -275,5 +275,8 @@ class Arg(Opt):
         exclude += ('dest',)
         return super()._params(exclude=exclude, **kwargs)
 
+    def make_metavar(self):
+        return None
+
     def make_options(self, *options: str, prefix=None, repl=None):
         return [self.dest]

--- a/argser/fields.py
+++ b/argser/fields.py
@@ -30,7 +30,6 @@ class Opt:
         bool_flag=True,
         prefix='--',
         repl=('_', '-'),
-        guess=False,
         **kwargs,
     ):
         """
@@ -70,9 +69,6 @@ class Opt:
         self.constructor = self._pick_constructor(constructor)
         self.bool_flag = bool_flag
         self.extra = kwargs
-
-        if guess:
-            self.guess_type_and_nargs()
 
     def __str__(self):
         names = ', '.join(self.options) or '-'

--- a/argser/fields.py
+++ b/argser/fields.py
@@ -1,65 +1,81 @@
 import logging
+import re
 from argparse import ArgumentParser, SUPPRESS
-from typing import Iterable
+from functools import partial
+from typing import Tuple, Optional, List
 
 from argser.logging import VERBOSE
-from argser.utils import str2bool
+from argser.utils import str2bool, is_list_like_type
 
+RE_OPT_PREFIX = re.compile(r'^([^\w]*)\w.*$')
 logger = logging.getLogger(__name__)
 
 
 class Opt:
-    """Option"""
+    """Optional Argument (eg: --arg, -a)"""
     def __init__(
         self,
+        *options: str,
         dest: str = None,
         default=None,
         type=None,
         nargs=None,
-        aliases: Iterable[str] = (),
         help=None,
         metavar=None,
         action=None,
         # argcomplete
         completer=None,
         # extra
+        constructor=None,
         bool_flag=True,
-        one_dash=False,
-        replace_underscores=True,
+        prefix='--',
+        repl=('_', '-'),
+        guess=False,
         **kwargs,
     ):
         """
-        :param dest:
-        :param default:
-        :param type:
-        :param nargs:
-        :param aliases:
-        :param help:
-        :param bool_flag:
-            if True then read bool from argument flag: `--arg` is True, `--no-arg` is False,
-            otherwise check if arg value and truthy or falsy: `--arg 1` is True `--arg no` is False
-        :param one_dash: use one dash for long names: `-name` instead of `--name`
-        :param replace_underscores: replace underscores in argument names with dashes
+        :param options: list of strings to be used as arguments name. Can be modified by :attr:`prefix` and :attr:`repl`
+        :param dest: destination in the namespace, can be prefixed with sub-parser name
+        :param default: default value
+        :param type: type of value that will be displayed in help message and used for type hints.
+        :param nargs: number of values
+        :param help: help text to display in help message alongside arguments
+        :param metavar: thingy that will be displayed near options with values: --args METAVAR
+        :param action: argparse action: count, append, store_const
+        :param completer: argcomplete completion function
+        :param constructor: callable that accepts a string and returns desirable value, default is :attr:`type`
+        :param bool_flag: if True then read bool from argument flag: `--arg` is True, `--no-arg` is False,
+               otherwise check if arg value and truthy or falsy: `--arg 1` is True `--arg no` is False
+        :param prefix: automatically prefix options with prefix.
+               If option is single letter then prefix will also be shortened. See :meth:`set_options`
+        :param repl: update provided options: replace first value in tuple with second value
         :param kwargs: extra arguments for `parser.add_argument`
         """
-        self.dest = dest
+        assert len(set(prefix)) < 2, "prefix should consist from the same characters, eg: --, ++, ..."
+
+        self.prefix = prefix
+        self.repl = repl
+        self.option_names = list(options)
+        # self.options = self.make_options(*options, prefix=prefix, repl=repl)
+        self.metavar = metavar
+        self.dest = self.set_dest(dest)
         self.type = type
         self.default = default
         self.nargs = nargs
-        self.aliases = aliases
         self.help = help
-        self._metavar = metavar
         self.action = action
         # argcomplete
         self.completer = completer
         # extra
+        self.constructor = self._pick_constructor(constructor)
         self.bool_flag = bool_flag
-        self.one_dash = one_dash
-        self.replace_underscores = replace_underscores
         self.extra = kwargs
 
+        if guess:
+            self.guess_type_and_nargs()
+
     def __str__(self):
-        names = ', '.join(self.keys()) or '-'
+        names = ', '.join(self.options) or '-'
         type_name = getattr(self.type, '__name__', None)
         return f"Arg({names}, type={type_name}, default={self.default!r})"
 
@@ -67,34 +83,133 @@ class Opt:
         return str(self)
 
     @property
-    def metavar(self):
-        if self._metavar:
-            return self._metavar
+    def name(self):
+        if self.dest:
+            return self.dest.split('__')[-1]
+
+    @property
+    def options(self):
+        return self.make_options(*self.option_names)
+
+    @property
+    def no_options(self):
+        sep = self.repl[1] if self.repl else '-'
+        res = []
+        for opt in self.options:
+            # prefix defined and used in this option
+            if self.prefix and opt.startswith(self.prefix[:1]):
+                prefix = self.prefix
+            else:
+                m = RE_OPT_PREFIX.match(opt)
+                prefix = m[1]
+            base = opt.lstrip(prefix)
+            key = f'{prefix}no{sep}{base}'
+            res.append(key)
+        return res
+
+    def set_dest(self, dest: str):
+        """Setup destination and related attributes. Should be called only once."""
+        if not dest:
+            return
+        if getattr(self, 'dest', None):
+            logger.warning("destination was already defined")
+            return
+        self.dest = dest
+        self.option_names += [dest]
+        self.metavar = self.metavar or self.make_metavar()
+        return self.dest
+
+    def _replace(self, opt: str, repl: Optional[Tuple[str, str]]):
+        if not repl:
+            return opt
+        sub, join = repl
+        return join.join(opt.split(sub))
+
+    def _prefix(self, opt: str, prefix: str):
+        if not opt[0].isalpha():
+            return opt
+        if len(opt) == 1:
+            return f'{prefix[:1]}{opt}'
+        return f'{prefix}{opt}'
+
+    def make_options(self, *options: str, prefix=None, repl=None):
+        """
+        >>> self.make_options('aaa', 'a', 'foo_bar', '+already_has', prefix='--', replace=('_', '+'))
+        ['--aaa', '-a', '--foo+bar', '+already+has']
+        """
+        prefix = prefix or self.prefix
+        repl = repl or self.repl
+        options = map(partial(self._replace, repl=repl), options)
+        options = map(partial(self._prefix, prefix=prefix), options)
+        options = list(options)
+        return options
+
+    def make_metavar(self):
         if self.dest:
             return self.dest[0].upper()
 
-    @property
-    def names(self):
-        names = [self.dest, *self.aliases]
-        return [n for n in names if n]
-
-    def keys(self, prefix=None):
-        names = self.names
-        if self.replace_underscores:
-            names = ['-'.join(n.split('_')) for n in names]
-        if prefix:
-            names = [f'{prefix}{n}' for n in names]
-        for name in names:
-            if len(name) == 1 or self.one_dash:
-                yield f"-{name}"
+    def _guess_nargs(self, typ, default):
+        """"""
+        # just list
+        if typ is list:
+            if len(default or []) == 0:
+                nargs = '*'
+                typ = str
             else:
-                yield f"--{name}"
+                nargs = '+'
+                typ = type(default[0])
+            return typ, nargs
+        #  List or List[str] or similar
+        if is_list_like_type(typ):
+            if typ.__args__ and isinstance(typ.__args__[0], type):
+                typ = typ.__args__[0]
+            else:
+                typ = str
+            nargs = '*' if len(default or []) == 0 else '+'
+            return typ, nargs
+        # non list type
+        return typ, None
 
-    def params(self, exclude=(), **kwargs):
+    def _guess_type_and_nargs(self, annotation, default, default_type):
+        # get type from annotation or from default value or fallback to str
+        if not default_type:
+            default_type = str if default is None else type(default)
+        typ = annotation or default_type
+        logger.log(VERBOSE, f"init type {typ}, default: {default}")
+        typ, nargs = self._guess_nargs(typ, default)
+        logger.log(VERBOSE, f"type {typ}, nargs {nargs!r}")
+        return typ, nargs
+
+    def _restore_type(self, typ, nargs, default):
+        if isinstance(nargs, int) or nargs in ('*', '+') or isinstance(default, list):
+            return List[typ]
+        return typ
+
+    def _pick_constructor(self, *values):
+        if len(values) == 1 and values[0] is None:
+            return
+        for val in values:
+            if callable(val):
+                return val
+        else:
+            raise ValueError(f"invalid constructors: {values}")
+
+    def guess_type_and_nargs(self, annotation=None):
+        """Based on annotation and default value guess type, nargs and constructor."""
+        typ, nargs = self._guess_type_and_nargs(annotation, self.default, self.type)
+        if self.action == 'append':
+            nargs = None
+        self.nargs = self.nargs or nargs
+        # user specified type -> annotation -> guessed type
+        self.type = self.type or annotation or self._restore_type(typ, self.nargs, self.default)
+        self.constructor = self._pick_constructor(self.constructor, typ)
+        return typ, nargs
+
+    def _params(self, exclude=(), **kwargs):
         params = dict(
             dest=self.dest,
             default=self.default,
-            type=self.type,
+            type=self.constructor,
             nargs=self.nargs,
             help=self.help,
             metavar=self.metavar,
@@ -109,50 +224,49 @@ class Opt:
 
     def inject_bool(self, parser: ArgumentParser):
         if self.bool_flag and self.nargs not in ('*', '+'):
-            params = self.params(exclude=('type', 'nargs', 'metavar', 'action'))
-            action = parser.add_argument(*self.keys(), action='store_true', **params)
+            params = self._params(exclude=('type', 'nargs', 'metavar', 'action'))
+            action = parser.add_argument(*self.options, action='store_true', **params)
             parser.set_defaults(**{self.dest: self.default})
             params['default'] = SUPPRESS  # don't print help message for second flag
             if 'help' in params:
                 del params['help']
-            parser.add_argument(*self.keys(prefix='no-'), action='store_false', **params)
+            parser.add_argument(*self.no_options, action='store_false', **params)
             return action
-        params = self.params(type=str2bool)
-        return parser.add_argument(*self.keys(), **params)
+        params = self._params(type=str2bool)
+        return parser.add_argument(*self.options, **params)
+
+    def _inject(self, parser: ArgumentParser):
+        params = self._params()
+        # action = params.get('action')
+        # if action in (
+        #     'store_const', 'store_true', 'store_false', 'append_const', 'version', 'count'
+        # ) and 'type' in params:
+        #     params.pop('type')
+        # if action in ('store_true', 'store_false', 'count', 'version') and 'metavar' in params:
+        #     params.pop('metavar')
+        action = parser.add_argument(*self.options, **params)
+        return action
 
     def inject(self, parser: ArgumentParser):
         logger.log(VERBOSE, f"adding {self.dest} to the parser")
-        if self.type is bool:
+        if self.constructor is bool:
             action = self.inject_bool(parser)
         else:
-            params = self.params()
-            action = params.get('action')
-            if action in (
-                'store_const', 'store_true', 'store_false', 'append_const', 'version', 'count'
-            ) and 'type' in params:
-                params.pop('type')
-            if action in ('store_true', 'store_false', 'count', 'version') and 'metavar' in params:
-                params.pop('metavar')
-            action = parser.add_argument(*self.keys(), **params)
+            action = self._inject(parser)
         if callable(self.completer):
             action.completer = self.completer
+        logger.log(VERBOSE, action)
+        setattr(action, '__meta', self)  # will be useful in help formatter
         return action
 
 
 class Arg(Opt):
     """Positional Argument"""
     def __init__(self, **kwargs):
-        kwargs.update(bool_flag=False)
+        # todo
+        kwargs.update(bool_flag=False, prefix='', repl=None)
         super().__init__(**kwargs)
 
-    @property
-    def metavar(self):
-        if self._metavar:
-            return self._metavar
-
-    def params(self, exclude=(), **kwargs):
+    def _params(self, exclude=(), **kwargs):
         exclude += ('dest',)
-        return super().params(exclude=exclude, **kwargs)
-
-    def keys(self, prefix=None):
-        return [self.dest] if self.dest else []
+        return super()._params(exclude=exclude, **kwargs)

--- a/argser/fields.py
+++ b/argser/fields.py
@@ -55,7 +55,6 @@ class Opt:
         self.prefix = prefix
         self.repl = repl
         self.option_names = list(options)
-        # self.options = self.make_options(*options, prefix=prefix, repl=repl)
         self.metavar = metavar
         self.dest = self.set_dest(dest)
         self.type = type
@@ -80,6 +79,7 @@ class Opt:
 
     @property
     def name(self):
+        """Destination w/o parser prefix."""
         if self.dest:
             return self.dest.split('__')[-1]
 
@@ -111,7 +111,7 @@ class Opt:
             logger.warning("destination was already defined")
             return
         self.dest = dest
-        self.option_names += [dest]
+        self.option_names += [self.name]
         self.metavar = self.metavar or self.make_metavar()
         return self.dest
 
@@ -142,7 +142,7 @@ class Opt:
 
     def make_metavar(self):
         if self.dest:
-            return self.dest[0].upper()
+            return self.name[0].upper()
 
     def _guess_nargs(self, typ, default):
         """

--- a/argser/formatters.py
+++ b/argser/formatters.py
@@ -24,28 +24,10 @@ class HelpFormatter(argparse.HelpFormatter):
             prefix = colored('usage', self.header_color) + ': '
         return super().add_usage(usage, actions, groups, prefix)
 
-    def _get_type_in_hard_core_mode(self, action: Action):
-        if action.type is None and isinstance(action.const, bool):
-            typ = bool
-        elif action.type is None and action.default is not None:
-            typ = type(action.default)
-        elif action.__class__.__name__ == '_CountAction':
-            typ = int
-        else:
-            typ = action.type
-        if typ is None and action.default is None:
-            typ = str
-        typ = getattr(typ, '__name__', '-')
-        if typ == 'str2bool':
-            typ = 'bool'
-        if action.nargs in ('*', '+') or action.__class__.__name__ == '_AppendAction':
-            typ = f"List[{typ}]"
-        return typ
-
     def _get_type(self, action: Action):
         meta: Opt = getattr(action, '__meta', None)
         if not meta:
-            return self._get_type_in_hard_core_mode(action)
+            return
         if isinstance(meta.type, type):
             typ = getattr(meta.type, '__name__', '-')
         else:
@@ -58,6 +40,8 @@ class HelpFormatter(argparse.HelpFormatter):
         if action.nargs == argparse.PARSER:
             return
         typ = self._get_type(action)
+        if not typ:
+            return
         typ = colored(typ, self.type_color)
         default = colored(repr(action.default), self.default_color)
         res = str(typ)

--- a/argser/formatters.py
+++ b/argser/formatters.py
@@ -1,8 +1,7 @@
 import argparse
 from argparse import Action
 
-from termcolor import colored
-
+from argser.utils import colored
 from argser.fields import Opt
 
 

--- a/argser/formatters.py
+++ b/argser/formatters.py
@@ -1,0 +1,92 @@
+import argparse
+from argparse import Action
+
+from termcolor import colored
+
+from argser.fields import Opt
+
+
+class HelpFormatter(argparse.HelpFormatter):
+    header_color = None
+    invoc_color = None
+    type_color = None
+    default_color = None
+
+    def __init__(self, prog, indent_increment=4, max_help_position=32, width=120):
+        super().__init__(prog, indent_increment, max_help_position, width)
+
+    def start_section(self, heading):
+        heading = colored(heading, self.header_color)
+        return super().start_section(heading)
+
+    def add_usage(self, usage, actions, groups, prefix=None):
+        if prefix is None:
+            prefix = colored('usage', self.header_color) + ': '
+        return super().add_usage(usage, actions, groups, prefix)
+
+    def _get_type_in_hard_core_mode(self, action: Action):
+        if action.type is None and isinstance(action.const, bool):
+            typ = bool
+        elif action.type is None and action.default is not None:
+            typ = type(action.default)
+        elif action.__class__.__name__ == '_CountAction':
+            typ = int
+        else:
+            typ = action.type
+        if typ is None and action.default is None:
+            typ = str
+        typ = getattr(typ, '__name__', '-')
+        if typ == 'str2bool':
+            typ = 'bool'
+        if action.nargs in ('*', '+') or action.__class__.__name__ == '_AppendAction':
+            typ = f"List[{typ}]"
+        return typ
+
+    def _get_type(self, action: Action):
+        meta: Opt = getattr(action, '__meta', None)
+        if not meta:
+            return self._get_type_in_hard_core_mode(action)
+        if isinstance(meta.type, type):
+            typ = getattr(meta.type, '__name__', '-')
+        else:
+            typ = str(meta.type)
+            typ = typ.replace('typing.', '')  # typing.List[str] -> List[str]
+        return str(typ)
+
+    def format_default_help(self, action: Action):
+        # skip if current action is sub-parser
+        if action.nargs == argparse.PARSER:
+            return
+        typ = self._get_type(action)
+        typ = colored(typ, self.type_color)
+        default = colored(repr(action.default), self.default_color)
+        res = str(typ)
+        if action.option_strings or action.default is not None:
+            res += f", default: {default}"
+        return res
+
+    def format_action_help(self, action):
+        if action.default == argparse.SUPPRESS:
+            return action.help
+        default_help_text = self.format_default_help(action)
+        if default_help_text:
+            if action.help:
+                return f"{default_help_text}. {action.help}"
+            return default_help_text
+        return action.help
+
+    def _format_action(self, action):
+        action.help = self.format_action_help(action)
+        # noinspection PyProtectedMember
+        text = super()._format_action(action)
+        invoc = self._format_action_invocation(action)
+        s = len(invoc) + self._current_indent
+        text = colored(text[:s], self.invoc_color) + text[s:]
+        return text
+
+
+class ColoredHelpFormatter(HelpFormatter):
+    header_color = 'yellow'
+    invoc_color = 'green'
+    type_color = 'red'
+    default_color = 'red'

--- a/argser/logging.py
+++ b/argser/logging.py
@@ -1,7 +1,7 @@
 import logging
 
-from argser.utils import colors
+from termcolor import colored
 
 VERBOSE = 5  # logging level lower than DEBUG
 logging.VERBOSE = VERBOSE
-logging.addLevelName(VERBOSE, colors.yellow('VERBOSE'))
+logging.addLevelName(VERBOSE, colored('VERBOSE', 'blue'))

--- a/argser/parse_func.py
+++ b/argser/parse_func.py
@@ -2,7 +2,7 @@ import inspect
 
 from types import FunctionType
 from argser.fields import Arg, Opt
-from argser.parser import parse_args, _get_type_and_nargs, sub_command
+from argser.parser import parse_args, sub_command
 
 
 def _get_default_args(func):
@@ -15,9 +15,7 @@ def _make_argument(name, annotations: dict, defaults: dict):
         arg = Opt(default=defaults[name])
     else:
         arg = Arg()
-    typ, nargs = _get_type_and_nargs(annotations, name, arg.default)
-    arg.type = typ
-    arg.nargs = nargs
+    arg.guess_type_and_nargs(annotations.get(name))
     return arg
 
 

--- a/argser/parser.py
+++ b/argser/parser.py
@@ -5,7 +5,7 @@ from argparse import ArgumentParser, Namespace
 from typing import Any, List, Type
 
 from argser.consts import Args, SUB_COMMAND_MARK
-from argser.display import print_args, stringify
+from argser.display import print_args, stringify, stringify_colored
 from argser.fields import Opt
 from argser.logging import VERBOSE
 from argser.formatters import ColoredHelpFormatter, HelpFormatter
@@ -208,11 +208,12 @@ def _make_shortcuts_sub_wise(args: List[Opt], sub_commands: dict):
         _make_shortcuts_sub_wise(args, sub_p)
 
 
-def sub_command(args_cls: Type[Args], **kwargs) -> Args:
+def sub_command(args_cls: Type[Args], colorize=True, **kwargs) -> Args:
     """
     Add sub-command to the parser.
 
     :param args_cls: data holder
+    :param colorize: use colored formatter
     :param kwargs: additional parser kwargs
     :return: instance of :attr:`args_cls` with added metadata
 
@@ -223,8 +224,9 @@ def sub_command(args_cls: Type[Args], **kwargs) -> Args:
     >>> args = parse_args(Args, 'sub -a 2')
     >>> assert args.sub.a == 2
     """
-    setattr(args_cls, '__str__', stringify)
-    setattr(args_cls, '__repr__', stringify)
+    to_str = stringify_colored if colorize else stringify
+    setattr(args_cls, '__str__', to_str)
+    setattr(args_cls, '__repr__', to_str)
     setattr(args_cls, '__kwargs', kwargs)
     setattr(args_cls, SUB_COMMAND_MARK, True)
     return args_cls()
@@ -318,7 +320,7 @@ def populate_holder(parser: ArgumentParser, args_cls: Type[Args], options: tuple
 
 
 def parse_args(
-    args_cls,
+    args_cls: Type[Args],
     args=None,
     *,
     show=None,
@@ -327,7 +329,7 @@ def parse_args(
     shorten=False,
     tabulate_kwargs=None,
     **kwargs,
-):
+) -> Args:
     """
     Parse arguments from string or command line and return populated instance of `args_cls`.
 

--- a/argser/parser.py
+++ b/argser/parser.py
@@ -1,7 +1,7 @@
 import logging
 import re
 import shlex
-from argparse import ArgumentParser, HelpFormatter, Namespace
+from argparse import ArgumentParser, Namespace
 from collections import defaultdict
 from typing import Any, List, Type
 
@@ -9,7 +9,7 @@ from argser.consts import Args, SUB_COMMAND_MARK
 from argser.display import print_args, stringify
 from argser.fields import Opt
 from argser.logging import VERBOSE
-from argser.utils import ColoredHelpFormatter
+from argser.formatters import ColoredHelpFormatter, HelpFormatter
 
 logger = logging.getLogger(__name__)
 
@@ -286,8 +286,8 @@ def make_parser(
     )
     if make_shortcuts:
         _make_shortcuts_sub_wise(args, sub_commands)
-    if colorize:
-        parser_kwargs.setdefault('formatter_class', ColoredHelpFormatter)
+    help_fmt_cls = ColoredHelpFormatter if colorize else HelpFormatter
+    parser_kwargs.setdefault('formatter_class', help_fmt_cls)
     parser = _make_parser('root', args, sub_commands, **parser_kwargs)
     _setup_argcomplete(parser, **argcomplete_kwargs)
     return parser, (args, sub_commands)
@@ -351,7 +351,7 @@ def parse_args(
     >>> args = parse_args(Args, '-a 1 -b 2.2 --no-c')
     >>> assert args.a == 1 and args.b == 2.2 and args.c is False
     """
-    parser, options = make_parser(args_cls, **kwargs)
+    parser, options = make_parser(args_cls, colorize=colorize, **kwargs)
     result = populate_holder(parser, args_cls, options, args)
 
     tabulate_kwargs = tabulate_kwargs or {}

--- a/argser/parser.py
+++ b/argser/parser.py
@@ -82,7 +82,7 @@ def _read_args(
                 else:
                     raise ValueError(
                         f"invalid value for {key}. "
-                        f"Tuple structure should be: default [help | [constructor, help]]"
+                        f"Tuple structure should be: (default, help) or (default, constructor, help)"
                     )
             option = Opt(
                 dest=key,
@@ -110,10 +110,6 @@ def _join_names(*names: str):
 
 def _uwrap(*names: str):
     return f'__{_join_names(*names)}__'
-
-
-def _get_prefix_chars(args: List[Opt]):
-    return
 
 
 def _make_parser(name: str, args: List[Opt], sub_commands: dict, formatter_class=HelpFormatter, **kwargs):
@@ -261,11 +257,12 @@ def make_parser(
     :param args_cls: class with defined arguments
     :param colorize: add colors to the help message and arguments printing
     :param make_shortcuts: make short version of arguments: ``--abc -> -a``, ``--abc_def -> --ad``
-    :param replace_underscores: replace underscores in argument names with dashes
     :param bool_flag:
         if True then read bool from argument flag: ``--arg`` is True, ``--no-arg`` is False,
         otherwise check if arg value and truthy or falsy: `--arg 1` is True `--arg no` is False
-    :param one_dash: use one dash for long names: `-`name`` instead of ``--name``
+    :param prefix: default prefix before options. For ``--``: ``aaa -> --aaa``, ``b -> -b``
+    :param repl: auto-replace some char with another char in option names.
+           For ``('_', '-')``: ``lang_name -> lang-name``
     :param override: override values above on Arg's
     :param parser_kwargs: root parser kwargs
     :param argcomplete_kwargs: argcomplete kwargs

--- a/argser/parser.py
+++ b/argser/parser.py
@@ -140,7 +140,7 @@ def _make_parser(name: str, args: List[Opt], sub_commands: dict, formatter_class
     sub_parser = parser.add_subparsers(dest=_uwrap(name))
 
     for sub_name, (args_cls, args, sub_p) in sub_commands.items():
-        p = _make_parser(_join_names(name, sub_name), args, sub_p)
+        p = _make_parser(_join_names(name, sub_name), args, sub_p, formatter_class)
         parser_kwargs = getattr(args_cls, '__kwargs', {})
         parser_kwargs.setdefault('formatter_class', formatter_class)
         sub_parser.add_parser(sub_name, parents=[p], add_help=False, **parser_kwargs)

--- a/argser/utils.py
+++ b/argser/utils.py
@@ -2,11 +2,17 @@ import re
 from argparse import ArgumentTypeError
 from functools import partial
 
-from termcolor import colored
+import termcolor
 
 from argser.consts import FALSE_VALUES, TRUE_VALUES
 
 RE_INV_CODES = re.compile(r"\x1b\[\d+[;\d]*m|\x1b\[\d*;\d*;\d*m")
+
+
+def colored(text, color=None):
+    if color is None:
+        return text
+    return termcolor.colored(text, color=color)
 
 
 def vlen(s: str):

--- a/argser/utils.py
+++ b/argser/utils.py
@@ -1,11 +1,11 @@
-import argparse
 import re
-from argparse import Action, ArgumentTypeError, HelpFormatter, SUPPRESS
+from argparse import ArgumentTypeError
 from functools import partial
+
+from termcolor import colored
 
 from argser.consts import FALSE_VALUES, TRUE_VALUES
 
-BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE = range(8)
 RE_INV_CODES = re.compile(r"\x1b\[\d+[;\d]*m|\x1b\[\d*;\d*;\d*m")
 
 
@@ -38,88 +38,9 @@ def is_list_like_type(t):
     return list in getattr(t, '__orig_bases__', []) or orig and issubclass(list, orig)
 
 
-def add_color(text, fg=None):  # pragma: no cover
-    """
-    :param text:
-    :param fg: [30, 38)
-    :return: text with ascii color
-
-    >>> assert add_color('text', 1) == '\x1b[31mtext\x1b[0m'
-    """
-    if fg is None:
-        return text
-    if not text:
-        text = ' '
-    return f'\x1b[{30 + fg}m{text}\x1b[0m'
-
-
 class colors:
-    red = partial(add_color, fg=RED)
-    green = partial(add_color, fg=GREEN)
-    yellow = partial(add_color, fg=YELLOW)
-    blue = partial(add_color, fg=BLUE)
+    red = partial(colored, color='red')
+    green = partial(colored, color='green')
+    yellow = partial(colored, color='yellow')
+    blue = partial(colored, color='blue')
     no = partial(lambda x: x)  # partial will prevent 'self' injection when called from ColoredHelpFormatter
-
-
-class ColoredHelpFormatter(HelpFormatter):
-    header_color = colors.yellow
-    invoc_color = colors.green
-    type_color = colors.red
-    default_color = colors.red
-
-    def __init__(self, prog, indent_increment=4, max_help_position=32, width=120):
-        super().__init__(prog, indent_increment, max_help_position, width)
-
-    def start_section(self, heading):
-        heading = self.header_color(heading)
-        return super().start_section(heading)
-
-    def add_usage(self, usage, actions, groups, prefix=None):
-        if prefix is None:
-            prefix = self.header_color('usage') + ': '
-        return super().add_usage(usage, actions, groups, prefix)
-
-    def format_default_help(self, action: Action):
-        # skip if current action is sub-parser
-        if action.nargs == argparse.PARSER:
-            return
-        if action.type is None and isinstance(action.const, bool):
-            typ = bool
-        elif action.type is None and action.default is not None:
-            typ = type(action.default)
-        elif action.__class__.__name__ == '_CountAction':
-            typ = int
-        else:
-            typ = action.type
-        if typ is None and action.default is None:
-            typ = str
-        typ = getattr(typ, '__name__', '-')
-        if typ == 'str2bool':
-            typ = 'bool'
-        if action.nargs in ('*', '+') or action.__class__.__name__ == '_AppendAction':
-            typ = f"List[{typ}]"
-        typ = self.type_color(typ)
-        default = self.default_color(repr(action.default))
-        res = str(typ)
-        if action.option_strings or action.default is not None:
-            res += f", default: {default}"
-        return res
-
-    def format_action_help(self, action):
-        if action.default == SUPPRESS:
-            return action.help
-        default_help_text = self.format_default_help(action)
-        if default_help_text:
-            if action.help:
-                return f"{default_help_text}. {action.help}"
-            return default_help_text
-        return action.help
-
-    def _format_action(self, action):
-        action.help = self.format_action_help(action)
-        # noinspection PyProtectedMember
-        text = super()._format_action(action)
-        invoc = self._format_action_invocation(action)
-        s = len(invoc) + self._current_indent
-        text = self.invoc_color(text[:s]) + text[s:]
-        return text

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,6 +1,7 @@
-import re
 import sys
 from pathlib import Path
+
+import argser
 
 root = Path(__file__).parents[2]
 package_dir = root / 'argser'
@@ -12,13 +13,8 @@ project = 'argser'
 copyright = '2019, Bachynin Ivan'
 author = 'Bachynin Ivan'
 
-# The full version, including alpha/beta/rc tags
-with open(root / 'pyproject.toml', 'r') as f:
-    version = re.search(r'version\s+=\s+"(.*)"', f.read(), flags=re.MULTILINE).group(1)
-
 # The full version, including alpha/beta/rc tags.
-print('version', version)
-release = version
+release = argser.__version__
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -123,17 +123,17 @@ positional arguments
     >>> assert args.b == 'foo bar'
 
 
-one dash
+different prefixes
 
 .. doctest::
 
     >>> from argser import Opt
 
     >>> class Args:
-    ...     aaa: int = Opt(one_dash=False)
-    ...     bbb: int = Opt(one_dash=True)
+    ...     aaa: int = Opt(prefix='-')
+    ...     bbb: int = Opt(prefix='++')
     
-    >>> args = parse_args(Args, '--aaa 42 -bbb 42')
+    >>> args = parse_args(Args, '-aaa 42 ++bbb 42')
     >>> assert args.aaa == 42
     >>> assert args.bbb == 42
 

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -44,6 +44,7 @@ Arguments
 *********
 
 str / int / float
+-----------------
 
 .. doctest::
 
@@ -61,6 +62,7 @@ str / int / float
 
 
 booleans
+--------
 
 .. doctest::
 
@@ -84,6 +86,7 @@ booleans
 
 
 lists
+-----
 
 .. doctest::
 
@@ -109,6 +112,7 @@ lists
 
 
 positional arguments
+--------------------
 
 .. doctest::
 
@@ -124,6 +128,7 @@ positional arguments
 
 
 different prefixes
+------------------
 
 .. doctest::
 
@@ -139,6 +144,7 @@ different prefixes
 
 
 argparse params
+---------------
 
 .. doctest::
 
@@ -154,6 +160,28 @@ argparse params
     >>> assert args.a == 'foo'
     >>> assert args.b == 3
     >>> assert args.c == [1, 2]
+
+
+constructors
+------------
+
+.. doctest::
+
+    >>> from argser import Opt
+
+    >>> def make_a(a: str):
+    ...     return int(a) + 42
+
+    >>> def make_b(b: str):
+    ...     return b + '42'
+
+    >>> class Args:
+    ...     a: int = Opt(constructor=make_a)
+    ...     b = 'default', make_b, "help message for be"
+
+    >>> args = parse_args(Args, '-a 2 -b "foo"')
+    >>> assert args.a == 44
+    >>> assert args.b == "foo42"
 
 
 Actions
@@ -239,6 +267,7 @@ Call function with parsed arguments
     ... ]
 
 Or as decorator:
+----------------
 
 .. doctest::
 
@@ -252,6 +281,7 @@ In examples above ``a`` (implicit string) and ``b`` (int) are positional argumen
 
 
 Multiple sub-commands:
+----------------------
 
 .. doctest::
 

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -300,6 +300,78 @@ Multiple sub-commands:
     ['1', 2]
 
 
+Override options globally
+*************************
+
+.. doctest::
+
+    >>> import argser
+    >>> class Args:
+    ...     a = 1
+    ...     b = True
+    ...     ccc_ddd = 'foo'
+
+    >>> args = argser.parse_args(
+    ...     Args,
+    ...     '+a 42 +b false +ccc+ddd "foo bar"',  # read from command if None
+    ...     make_shortcuts=False,  # +ccc+ddd will not generate cd now
+    ...     bool_flag=False,  # bool arg will require bool value near flag
+    ...     prefix='+',  # change default prefix
+    ...     repl=('_', '+'),  # change auto-replacer options (from, to)
+    ...     override=True,  # only required if you need to override args defined with Opt/Arg
+    ... )
+
+    >>> assert args.a == 42
+    >>> assert args.b is False
+    >>> assert args.ccc_ddd == 'foo bar'
+
+
+Display arguments
+*****************
+
+.. doctest::
+    
+    >>> from argser import sub_command, parse_args  
+    >>> class Args:
+    ...     a = 1
+    ...     b = 'foo'
+    ...     class Sub:
+    ...         a = 'foo bar'
+    ...     sub = sub_command(Sub)
+    >>> args = parse_args(
+    ...     Args,
+    ...     '-a 42 sub -a "fooooooooo baaaaaaaaaaaaaaar baaaaaaaaaaaaaaar"',
+    ...     show='table',
+    ... )
+    arg    value     arg     value                       
+    -----  -------   ------  ----------------------------
+    a      42        sub__a  fooooooooo baaaaaaaaaaaaaaar
+    b      foo               baaaaaaaaaaaaaaar           
+
+
+Or in one line:
+
+.. doctest::
+    
+    >>> args = parse_args(  
+    ...     Args,
+    ...     '-a 42 sub -a "fooooooooo baaaaaaaaaaaaaaar baaaaaaaaaaaaaaar"',
+    ...     show=True,
+    ... )
+    Args(a=42, b='foo', sub=Sub(a='fooooooooo baaaaaaaaaaaaaaar baaaaaaaaaaaaaaar'))
+    
+Or after parsing:
+
+.. doctest::
+
+    >>> from argser import print_args
+    >>> print_args(args, 'table')
+    arg    value     arg     value                       
+    -----  -------   ------  ----------------------------
+    a      42        sub__a  fooooooooo baaaaaaaaaaaaaaar
+    b      foo               baaaaaaaaaaaaaaar   
+
+
 Auto completion
 ***************
 

--- a/docs/source/modules/argser.formatters.rst
+++ b/docs/source/modules/argser.formatters.rst
@@ -1,0 +1,7 @@
+argser.formatters module
+========================
+
+.. automodule:: argser.formatters
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/modules/argser.rst
+++ b/docs/source/modules/argser.rst
@@ -8,6 +8,7 @@ Submodules
 
    argser.display
    argser.fields
+   argser.formatters
    argser.parse_func
    argser.parser
    argser.utils

--- a/poetry.lock
+++ b/poetry.lock
@@ -414,6 +414,14 @@ python-versions = "*"
 version = "0.8.5"
 
 [[package]]
+category = "main"
+description = "ANSII Color formatting for output in terminal."
+name = "termcolor"
+optional = false
+python-versions = "*"
+version = "1.1.0"
+
+[[package]]
 category = "dev"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 name = "urllib3"
@@ -447,7 +455,7 @@ argcomplete = ["argcomplete"]
 tabulate = ["tabulate"]
 
 [metadata]
-content-hash = "b9d305e13d31d0c9fe3c6a2763831c2ed231aa0e9fd85696374a4129ddc799e6"
+content-hash = "bae809b48c333a715be1e3ec40cd720c13fb737b5ed61661a592e59c4a0dc95e"
 python-versions = "^3.6"
 
 [metadata.hashes]
@@ -493,6 +501,7 @@ sphinxcontrib-jsmath = ["2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c
 sphinxcontrib-qthelp = ["513049b93031beb1f57d4daea74068a4feb77aa5630f856fcff2e50de14e9a20", "79465ce11ae5694ff165becda529a600c754f4bc459778778c7017374d4d406f"]
 sphinxcontrib-serializinghtml = ["c0efb33f8052c04fd7a26c0a07f1678e8512e0faec19f4aa8f2473a8b81d5227", "db6615af393650bf1151a6cd39120c29abaf93cc60db8c48eb2dddbfdc3a9768"]
 tabulate = ["d0097023658d4dea848d6ae73af84532d1e86617ac0925d1adf1dd903985dac3"]
+termcolor = ["1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"]
 urllib3 = ["3de946ffbed6e6746608990594d08faac602528ac7015ac28d33cee6a45b7398", "9a107b99a5393caf59c7aa3c1249c16e6879447533d0887f4336dde834c7be86"]
 wcwidth = ["3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e", "f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"]
 zipp = ["3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e", "f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -271,6 +271,17 @@ six = "*"
 
 [[package]]
 category = "dev"
+description = "py.test plugin that allows you to add environment variables."
+name = "pytest-env"
+optional = false
+python-versions = "*"
+version = "0.6.2"
+
+[package.dependencies]
+pytest = ">=2.6.0"
+
+[[package]]
+category = "dev"
 description = "World timezone definitions, modern and historical"
 name = "pytz"
 optional = false
@@ -455,7 +466,7 @@ argcomplete = ["argcomplete"]
 tabulate = ["tabulate"]
 
 [metadata]
-content-hash = "bae809b48c333a715be1e3ec40cd720c13fb737b5ed61661a592e59c4a0dc95e"
+content-hash = "8b33f5b6755b46b7bf84235875cb5b25c38131ebda5f971cad682fbdbe916e03"
 python-versions = "^3.6"
 
 [metadata.hashes]
@@ -487,6 +498,7 @@ pyparsing = ["6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80",
 pytest = ["7e4800063ccfc306a53c461442526c5571e1462f61583506ce97e4da6a1d88c8", "ca563435f4941d0cb34767301c27bc65c510cb82e90b9ecf9cb52dc2c63caaa0"]
 pytest-cov = ["cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b", "cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626"]
 pytest-doctestplus = ["8872b9c236924af20c39c2813d7f1bde50a1edca7c4aba5a8bfbae3a32360e87"]
+pytest-env = ["7e94956aef7f2764f3c147d216ce066bf6c42948bb9e293169b1b1c880a580c2"]
 pytz = ["1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d", "b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"]
 requests = ["11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4", "9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"]
 six = ["3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c", "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
 python = "^3.6"
 tabulate = {version = "^0.8.5", optional = true}
 argcomplete = {version = "^1.10", optional = true}
+termcolor = "^1.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ sphinx-rtd-theme = "^0.4.3"
 sphinxcontrib-apidoc = "^0.3.0"
 m2r = "^0.2.1"
 pytest-doctestplus = "^0.4.0"
+pytest-env = "^0.6.2"
 
 [tool.poetry.extras]
 tabulate = ["tabulate"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,3 +8,7 @@ log_format=%(levelname)-7s %(name)16s:%(lineno)-3s > %(message)s
 doctest_plus = enabled
 text_file_format = rst
 doctest_rst = True
+doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE
+
+env = 
+    ANSI_COLORS_DISABLED=1

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,6 +1,7 @@
 import textwrap
 
-from argser import parse_args, sub_command, make_table, Opt
+from argser import parse_args, sub_command, Opt
+from argser.display import make_table
 
 
 def test_prints():

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -234,16 +234,3 @@ class TestGuessType:
         p = ArgumentParser()
         o.inject(p)
         assert p.parse_args('-o 123'.split()).o == [2, 3, 4]
-
-
-@pytest.fixture
-def parser():
-    return ArgumentParser()
-
-
-class TestInject:
-    def test(self, parser: ArgumentParser):
-        o = Opt(dest='arg')
-        action = o.inject(parser)
-        print(action)
-        # assert 0

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,0 +1,249 @@
+from argparse import ArgumentParser
+from typing import List
+
+import pytest
+
+from argser import Opt
+
+
+def test_opt_replace():
+    o = Opt()
+    assert o._replace('aa', ('_', '-')) == 'aa'
+    assert o._replace('aa_aa', ('_', '-')) == 'aa-aa'
+    assert o._replace('aa__bb_cc', ('_', '+')) == 'aa++bb+cc'
+    assert o._replace('a-b-c', ('-', '_')) == 'a_b_c'
+    assert o._replace('a_b_c', None) == 'a_b_c'
+
+
+def test_opt_prefix():
+    o = Opt()
+    assert o._prefix('aa', '') == 'aa'
+    assert o._prefix('aa', '-') == '-aa'
+    assert o._prefix('aa', '--') == '--aa'
+    assert o._prefix('a', '--') == '-a'
+    assert o._prefix('+aa', '--') == '+aa'
+
+
+def test_set_options():
+    o = Opt()
+    assert o.make_options('a', 'aa', 'aa_bb') == ['-a', '--aa', '--aa-bb']
+    assert o.make_options('a', 'aa', 'aa_bb', prefix='+', repl=('_', '+')) == ['+a', '+aa', '+aa+bb']
+
+
+def test_no_options():
+    assert Opt('a', 'aa', 'aa_bb').no_options == ['--no-a', '--no-aa', '--no-aa-bb']
+    assert Opt('++aa').no_options == ['++no-aa']
+    assert Opt('++aa', prefix='').no_options == ['++no-aa']
+    assert Opt('++aa', prefix='').no_options == ['++no-aa']
+    assert Opt('++aa', repl=('_', '+')).no_options == ['++no+aa']
+    assert Opt('aa', prefix='+').no_options == ['+no-aa']
+    assert Opt('aa', prefix='+', repl=('_', '+')).no_options == ['+no+aa']
+
+
+def test_init():
+    o = Opt()
+    assert o.dest is None
+    assert o.options == []
+
+    o = Opt(dest='foo')
+    assert o.dest == 'foo'
+    assert o.options == ['--foo']
+    assert o.metavar == 'F'
+    o.set_dest('bar')  # dest already specified
+    assert o.dest == 'foo'
+    assert o.options == ['--foo']
+    assert o.metavar == 'F'
+
+    o = Opt('bar', dest='foo')
+    assert o.dest == 'foo'
+    assert set(o.options) == {'--foo', '--bar'}
+    assert o.metavar == 'F'
+
+    o = Opt('bar', 'baz')
+    assert o.dest is None
+    assert o.options == ['--bar', '--baz']
+    assert o.metavar is None
+
+    o = Opt('bar', 'baz')
+    o.set_dest('foo')
+    assert o.dest == 'foo'
+    assert set(o.options) == {'--foo', '--bar', '--baz'}
+    assert o.metavar == 'F'
+
+
+class TestGuessType:
+    def test_simple(self):
+        o = Opt()
+        typ, nargs = o.guess_type_and_nargs(annotation=None)
+        assert o.type is typ is str
+        assert o.constructor is str
+        assert o.nargs is nargs is None
+
+        o = Opt()
+        typ, nargs = o.guess_type_and_nargs(annotation=int)
+        assert o.type is typ is int
+        assert o.constructor is int
+        assert o.nargs is nargs is None
+
+        o = Opt()
+        typ, nargs = o.guess_type_and_nargs(annotation=List[float])
+        assert o.type == List[float]
+        assert o.constructor is typ is float
+        assert o.nargs is nargs is '*'
+
+    def test_with_type(self):
+        o = Opt(type=int)
+        o.guess_type_and_nargs(annotation=None)
+        assert o.type is int
+        assert o.constructor is int
+        assert o.nargs is None
+
+        o = Opt(type=List[int])
+        o.guess_type_and_nargs(annotation=None)
+        assert o.type is List[int]
+        assert o.constructor is int
+        assert o.nargs == '*'
+
+        o = Opt(type=List[int])
+        o.guess_type_and_nargs(annotation=int)  # try override type with annotation
+        assert o.type is List[int]  # but fail miserably
+        assert o.constructor is int
+        assert o.nargs is None
+
+    def test_with_default(self):
+        o = Opt(default=1)
+        o.guess_type_and_nargs(annotation=None)
+        assert o.type is int
+        assert o.constructor is int
+        assert o.nargs is None
+
+        o = Opt(default=1)
+        o.guess_type_and_nargs(annotation=float)
+        assert o.type is float
+        assert o.constructor is float
+        assert o.nargs is None
+
+        o = Opt(default=[])
+        o.guess_type_and_nargs(annotation=None)
+        assert o.type == List[str]
+        assert o.constructor is str
+        assert o.nargs == '*'
+
+        o = Opt(default=[])
+        o.guess_type_and_nargs(annotation=List[bool])
+        assert o.type == List[bool]
+        assert o.constructor is bool
+        assert o.nargs == '*'
+
+        o = Opt(default=[1.1])
+        o.guess_type_and_nargs(annotation=None)
+        assert o.type == List[float]
+        assert o.constructor is float
+        assert o.nargs == '+'
+
+    def test_with_constructor(self):
+        o = Opt(constructor=lambda x: x.upper())
+        o.guess_type_and_nargs(annotation=None)
+        assert o.type is str
+        assert o.constructor('a') == 'A'
+        assert o.nargs is None
+
+        # user error: type and constructor result mismatch
+        o = Opt(constructor=lambda x: x.upper())
+        o.guess_type_and_nargs(annotation=int)
+        assert o.type is int
+        assert o.constructor('a') == 'A'
+        assert o.nargs is None
+
+        o = Opt(constructor=lambda x: float(x) + 2.2)
+        o.guess_type_and_nargs(annotation=float)
+        assert o.type is float
+        assert o.constructor('1.1') == pytest.approx(3.3)
+        assert o.nargs is None
+
+        o = Opt(constructor=lambda x: list(map(int, x)))
+        o.guess_type_and_nargs(annotation=List[int])
+        assert o.type is List[int]
+        assert o.constructor('123') == [1, 2, 3]
+        assert o.nargs == '*'
+
+    def test_with_nargs(self):
+        o = Opt(nargs='?')
+        o.guess_type_and_nargs(annotation=None)
+        assert o.type is str
+        assert o.constructor is str
+        assert o.nargs == '?'
+
+        o = Opt(nargs='*')
+        o.guess_type_and_nargs(annotation=None)
+        assert o.type == List[str]
+        assert o.constructor is str
+        assert o.nargs == '*'
+
+        o = Opt(nargs='+')
+        o.guess_type_and_nargs(annotation=None)
+        assert o.type == List[str]
+        assert o.constructor is str
+        assert o.nargs == '+'
+
+        o = Opt(nargs=2)
+        o.guess_type_and_nargs(annotation=None)
+        assert o.type == List[str]
+        assert o.constructor is str
+        assert o.nargs == 2
+
+    def test_complex(self):
+        o = Opt(type=str, constructor=lambda x: x.upper())
+        o.guess_type_and_nargs(annotation=None)
+        assert o.type is str
+        assert o.constructor('a') == 'A'
+        assert o.nargs is None
+
+        o = Opt(default=1.1, constructor=lambda x: float(x) + 1)
+        o.guess_type_and_nargs(annotation=None)
+        assert o.type is float
+        assert o.constructor('1.1') == pytest.approx(2.1)
+        assert o.nargs is None
+
+        o = Opt('o', type=bool, constructor=lambda x: x == 'foo')
+        o.guess_type_and_nargs(annotation=None)
+        assert o.type is bool
+        assert o.constructor('foo') is True
+        assert o.nargs is None
+        p = ArgumentParser()
+        o.inject(p)
+        assert p.parse_args('-o foo'.split()).o is True
+        assert p.parse_args('-o bar'.split()).o is False
+
+        o = Opt('o', default=[1, 2], constructor=lambda x: int(x) + 1)
+        o.guess_type_and_nargs(annotation=None)
+        assert o.type == List[int]
+        assert o.constructor('1') == 2
+        assert o.nargs == '+'
+        p = ArgumentParser()
+        o.inject(p)
+        assert p.parse_args('-o 1 2'.split()).o == [2, 3]
+        assert p.parse_args('-o 5 1 2'.split()).o == [6, 2, 3]
+
+    def test_list_from_single_value(self):
+        o = Opt('o', constructor=lambda x: [int(e) + 1 for e in list(x)], nargs='?', default=[-1])
+        o.guess_type_and_nargs(annotation=None)
+        assert o.type == List[int]
+        assert o.constructor('123') == [2, 3, 4]
+        assert o.nargs == '?'
+        p = ArgumentParser()
+        o.inject(p)
+        assert p.parse_args('-o 123'.split()).o == [2, 3, 4]
+
+
+@pytest.fixture
+def parser():
+    return ArgumentParser()
+
+
+class TestInject:
+    def test(self, parser: ArgumentParser):
+        o = Opt(dest='arg')
+        action = o.inject(parser)
+        print(action)
+        # assert 0

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -234,3 +234,14 @@ class TestGuessType:
         p = ArgumentParser()
         o.inject(p)
         assert p.parse_args('-o 123'.split()).o == [2, 3, 4]
+
+
+def test_pick_constructor():
+    def foo():
+        pass
+
+    assert Opt()._pick_constructor(1, 2, foo) is foo
+    assert Opt()._pick_constructor(1, foo, 2) is foo
+    assert Opt()._pick_constructor(None) is None
+    with pytest.raises(ValueError):
+        Opt()._pick_constructor(1, 2, 3)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -203,10 +203,10 @@ def test_parse_bool():
     assert args.a is True
     args = parse_args(Args, '--no-a', bool_flag=True)
     assert args.a is False
-    args = parse_args(Args, '-no-a', bool_flag=True, one_dash=True)
+    args = parse_args(Args, '-no-a', bool_flag=True, prefix='-')
     assert args.a is False
 
-    args = parse_args(Args, '-no-b -c', bool_flag=True, one_dash=True)
+    args = parse_args(Args, '-no-b -c', bool_flag=True, prefix='-')
     assert args.b is False
     assert args.c is True
 
@@ -262,11 +262,16 @@ class TestList:
 
     def test_types(self, list_args):
         args_cls, (a, b, c, d, e), sub_commands = _read_args(list_args().__class__)
-        assert a.type is str
-        assert b.type is str
-        assert c.type is int
-        assert d.type is bool
-        assert e.type is float
+        assert a.type is list  # because of annotation
+        assert a.constructor is str
+        assert b.type == List  # ^ same
+        assert b.constructor is str
+        assert c.type == List[int]
+        assert c.constructor is int
+        assert d.type == List[bool]
+        assert d.constructor is bool
+        assert e.type == List[float]
+        assert e.constructor is float
 
 
 def test_non_standard_type():
@@ -307,22 +312,22 @@ def test_custom_type():
 
 def test_override():
     class Args:
-        aa = Opt(default='foo', one_dash=True)
-        bb = Opt(default='bar', one_dash=False)
+        aa = Opt(default='foo', prefix='-')
+        bb = Opt(default='bar', prefix='--')
         cc = 'baz'
 
-    args = parse_args(Args, '-aa foo1 --bb bar1 -cc baz1', override=False, one_dash=True)
+    args = parse_args(Args, '-aa foo1 --bb bar1 -cc baz1', override=False, prefix='-')
     assert args.aa == 'foo1'
     assert args.bb == 'bar1'
     assert args.cc == 'baz1'
 
-    args = parse_args(Args, '--aa foo1 --bb bar1 --cc baz1', override=True, one_dash=False)
+    args = parse_args(Args, '--aa foo1 --bb bar1 --cc baz1', override=True, prefix='--')
     assert args.aa == 'foo1'
     assert args.bb == 'bar1'
     assert args.cc == 'baz1'
 
     with pytest.raises(SystemExit):
-        parse_args(Args, '-aa foo1 --bb bar1 -cc baz1', override=True, one_dash=False)
+        parse_args(Args, '-aa foo1 --bb bar1 -cc baz1', override=True, prefix='--')
 
 
 def test_action_store():
@@ -381,7 +386,7 @@ class TestAction:
 
     def test_version(self):
         class Args:
-            version: str = Opt(action='version', version='%(prog)s 0.0.1', aliases=('V',))
+            version: str = Opt('V', action='version', version='%(prog)s 0.0.1')
 
         with pytest.raises(SystemExit, match='0'):
             parse_args(Args, '-V', parser_kwargs=dict(prog='PROG'))
@@ -413,24 +418,28 @@ def test_make_shortcuts():
     bc = Opt(dest='bc', type=str)
     ab_cd = Opt(dest='ab_cd', type=str)
     ab_cde = Opt(dest='ab_cde', type=str)
-    bcd = Arg(dest='bcd', type=str, aliases=('foo',))
-    f1 = Opt(dest='f1', aliases=('f3',), type=str)
+    bcd = Opt('foo', dest='bcd', type=str)
+    f1 = Opt('f3', dest='f1', type=str)
     f2_3 = Opt(dest='f2_3', type=str)
     # sub
     aaa = Opt(dest='aaa', type=str)
     ab_cd2 = Opt(dest='ab_cd', type=str)
 
+    def comp_names(opt: Opt, *names):
+        return set(opt.option_names) == set(names)
+
     _make_shortcuts_sub_wise([a, aa, bc, ab_cd, ab_cde, bcd, f1, f2_3], {'sub': (None, [aaa, ab_cd2], {})})
-    assert a.dest == 'a' and a.aliases == ()  # already short name
-    assert aa.dest == 'aa' and aa.aliases == ()  # name 'a' already exists
-    assert bc.dest == 'bc' and bc.aliases == ('b',)
-    assert ab_cd.dest == 'ab_cd' and ab_cd.aliases == ('ac',)
-    assert ab_cde.dest == 'ab_cde' and ab_cde.aliases == ()
-    assert bcd.dest == 'bcd' and bcd.aliases == ('foo',)  # alias was already defined and override is false
-    assert aaa.dest == 'aaa' and aaa.aliases == ('a',)
-    assert ab_cd2.dest == 'ab_cd' and ab_cd2.aliases == ('ac',)
-    assert f1.aliases == ('f3',)
-    assert f2_3.aliases == ()
+    assert a.dest == 'a' and comp_names(a, 'a')  # already short name
+    assert aa.dest == 'aa' and comp_names(aa, 'aa')  # name 'a' already exists
+    assert bc.dest == 'bc' and comp_names(bc, 'b', 'bc')
+    assert ab_cd.dest == 'ab_cd' and comp_names(ab_cd, 'ac', 'ab_cd')
+    assert ab_cde.dest == 'ab_cde' and comp_names(ab_cde, 'ab_cde')  # ac is taken
+    assert bcd.dest == 'bcd' and comp_names(bcd, 'foo', 'bcd')  # alias was already defined and override is false
+    assert comp_names(f1, 'f1', 'f3')
+    assert comp_names(f2_3, 'f2_3')
+    # sub
+    assert aaa.dest == 'aaa' and comp_names(aaa, 'a', 'aaa')
+    assert ab_cd2.dest == 'ab_cd' and comp_names(ab_cd2, 'ac', 'ab_cd')  # dest was changed
 
 
 def test_reusability():
@@ -467,3 +476,27 @@ def test_reusability():
     assert args.c == 'c'
     assert args.e == 'foo bar'
     assert args.g is False
+
+
+def test_prefix():
+    class Args:
+        aaa: int = Opt(prefix='-')
+        bbb: int = Opt(prefix='++')
+
+    args = parse_args(Args, '-aaa 42 ++bbb 42')
+    assert args.aaa == 42
+    assert args.bbb == 42
+
+
+def test_constructor():
+    class Args:
+        a: List[int] = Opt(constructor=lambda x: [int(e) + 1 for e in list(x)], nargs='?', default=[-1])
+        b: int = Opt(constructor=lambda x: int(x) + 2)
+
+    args = parse_args(Args, '')
+    assert args.a == [-1]
+    assert args.b is None
+
+    args = parse_args(Args, '-a 123 -b 5')
+    assert args.a == [2, 3, 4]
+    assert args.b == 7

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,7 +3,6 @@ from typing import Callable, List
 
 import pytest
 
-import argser
 from argser import Arg, Opt, parse_args, sub_command
 # noinspection PyProtectedMember
 from argser.parser import _make_shortcuts_sub_wise, _read_args
@@ -500,3 +499,30 @@ def test_constructor():
     args = parse_args(Args, '-a 123 -b 5')
     assert args.a == [2, 3, 4]
     assert args.b == 7
+
+
+def test_quick_help():
+    class Args:
+        # default, help
+        a = 1, "help for a"
+        # with annotation parenthesis are required
+        b: str = (None, "help for b")
+        # default, constructor, help
+        c: float = (5., lambda x: float(x) * 2, "help for b")
+
+    args = parse_args(Args, '')
+    assert args.a == 1
+    assert args.b is None
+    assert args.c == pytest.approx(5.)
+
+    args = parse_args(Args, '-a 2 -b "foo bar" -c 10')
+    assert args.a == 2
+    assert args.b == 'foo bar'
+    assert args.c == pytest.approx(20.)
+
+    class Args:
+        e = ('foo', str, "help", "some trash no one asked for")
+
+    with pytest.raises(ValueError) as context:
+        parse_args(Args, '')
+    assert '(default, help) or (default, constructor, help)' in str(context.value)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,8 @@ import os
 import textwrap
 from typing import List
 
+import pytest
+
 from argser import Opt, sub_command
 # noinspection PyProtectedMember
 from argser.parser import _read_args, _make_parser
@@ -26,67 +28,150 @@ def test_cli():
     autocomplete(args)
 
 
-def test_help():
-    os.environ['ANSI_COLORS_DISABLED'] = '1'  # disable colorization of help message
+@pytest.fixture(autouse=True)
+def _ansi_color_disable():
+    os.environ['ANSI_COLORS_DISABLED'] = '1'
 
-    class Base:
-        bb: bool = Opt(default=True, help="foo bar")
 
-    class Args(Base):
-        b: bool
-        b1 = True
-        l0 = []
-        l1 = [1]
-        l2: List[float] = None
-        f = 2.3
-        c = Opt(default=5, metavar='N', choices=[1, 2, 5])
-        dddd = 3
-        foo_bar_baaaaaaaaz = 3
-        v: int = Opt(action='count', default=0)
-        v1: int = Opt(action='count', help='bar')
-        v2: int = Opt(action='count', help="foo")
-        ap: List[str] = Opt(action='append')
+class TestHelpFormatting:
+    def compare(self, args_cls, help_text: str):
+        args_cls, args, sub_commands = _read_args(args_cls)
+        parser = _make_parser('root', args, sub_commands, prog='prog')
+        help_msg = parser.format_help()
+        print(help_msg)
+        real_help = textwrap.dedent(help_text)
+        assert real_help.strip('\n ') == help_msg.strip('\n ')
 
-        class Sub:
-            d = 1
-            e = '2'
+    def test_lists(self):  # disable colorization of help message
+        class Args:
+            l0 = []
+            l1 = [1]
+            l2: List[float] = None
+            ap: List[str] = Opt(action='append')
 
-        sub = sub_command(Sub, help='sub1 help')
+        # sometime python3.6 behave strangely and miss inner type in List
+        try:
+            self.compare(
+                Args,
+                """
+                usage: prog [-h] [--l0 [L [L ...]]] [--l1 L [L ...]] [--l2 [L [L ...]]] [--ap A]
+    
+                optional arguments:
+                    -h, --help        show this help message and exit
+                    --l0 [L [L ...]]  List[str], default: []
+                    --l1 L [L ...]    List[int], default: [1]
+                    --l2 [L [L ...]]  List[float], default: None
+                    --ap A            List[str], default: None
+                """,
+            )
+        except AssertionError:
+            self.compare(
+                Args,
+                """
+                usage: prog [-h] [--l0 [L [L ...]]] [--l1 L [L ...]] [--l2 [L [L ...]]] [--ap A]
 
-    args_cls, args, sub_commands = _read_args(Args)
-    parser = _make_parser('root', args, sub_commands, prog='prog')
-    help_msg = parser.format_help()
-    print(help_msg)
-    real_help = textwrap.dedent(
-        """
-        usage: prog [-h] [-b] [--no-b] [--b1] [--no-b1] [--l0 [L [L ...]]] [--l1 L [L ...]] [--l2 [L [L ...]]] [-f F] [-c N]
-                    [--dddd D] [--foo-bar-baaaaaaaaz F] [-v] [--v1] [--v2] [--ap A] [--bb] [--no-bb]
-                    {sub} ...
+                optional arguments:
+                    -h, --help        show this help message and exit
+                    --l0 [L [L ...]]  List, default: []
+                    --l1 L [L ...]    List, default: [1]
+                    --l2 [L [L ...]]  List, default: None
+                    --ap A            List, default: None
+                """,
+            )
 
-        positional arguments:
-            {sub}
-                sub                 sub1 help
+    def test_with_base(self):
+        class Base:
+            bb: bool = Opt(default=True, help="foo bar")
 
-        optional arguments:
-            -h, --help              show this help message and exit
-            -b                      bool, default: None
-            --no-b
-            --b1                    bool, default: True
-            --no-b1
-            --l0 [L [L ...]]        List[str], default: []
-            --l1 L [L ...]          List[int], default: [1]
-            --l2 [L [L ...]]        List[float], default: None
-            -f F                    float, default: 2.3
-            -c N                    int, default: 5
-            --dddd D                int, default: 3
-            --foo-bar-baaaaaaaaz F  int, default: 3
-            -v                      int, default: 0
-            --v1                    int, default: None. bar
-            --v2                    int, default: None. foo
-            --ap A                  List[str], default: None
-            --bb                    bool, default: True. foo bar
-            --no-bb
-        """
-    )
+        class Args(Base):
+            b: bool
+            b1 = True
 
-    assert real_help.strip('\n ') == help_msg.strip('\n ')
+        self.compare(
+            Args,
+            """
+            usage: prog [-h] [-b] [--no-b] [--b1] [--no-b1] [--bb] [--no-bb]
+
+            optional arguments:
+                -h, --help  show this help message and exit
+                -b          bool, default: None
+                --no-b
+                --b1        bool, default: True
+                --no-b1
+                --bb        bool, default: True. foo bar
+                --no-bb
+            """,
+        )
+
+    def test_sub_command(self):
+        class Args:
+            a = 1.1
+
+            class Sub:
+                d = 1
+                e = '2'
+
+            sub = sub_command(Sub, help='sub1 help')
+
+        self.compare(
+            Args,
+            """
+            usage: prog [-h] [-a A] {sub} ...
+
+            positional arguments:
+                {sub}
+                    sub     sub1 help
+            
+            optional arguments:
+                -h, --help  show this help message and exit
+                -a A        float, default: 1.1
+            """,
+        )
+
+    def test_actions(self):
+        class Args:
+            v: int = Opt(action='count', default=0)
+            v1: int = Opt(action='count', help='bar')
+            v2: int = Opt(action='count', help="foo")
+            ap: List[str] = Opt(action='append')
+
+        self.compare(
+            Args,
+            """
+            usage: prog [-h] [-v] [--v1] [--v2] [--ap A]
+
+            optional arguments:
+                -h, --help  show this help message and exit
+                -v          int, default: 0
+                --v1        int, default: None. bar
+                --v2        int, default: None. foo
+                --ap A      List[str], default: None
+            """,
+        )
+
+    def test_mix(self):
+        class Args:
+            b: bool
+            b1 = True
+            f = 2.3
+            c = Opt(default=5, metavar='N', choices=[1, 2, 5])
+            dddd = 3
+            foo_bar_baaaaaaaaz = 3
+
+        self.compare(
+            Args,
+            """
+            usage: prog [-h] [-b] [--no-b] [--b1] [--no-b1] [-f F] [-c N] [--dddd D] [--foo-bar-baaaaaaaaz F]
+
+            optional arguments:
+                -h, --help              show this help message and exit
+                -b                      bool, default: None
+                --no-b
+                --b1                    bool, default: True
+                --no-b1
+                -f F                    float, default: 2.3
+                -c N                    int, default: 5
+                --dddd D                int, default: 3
+                --foo-bar-baaaaaaaaz F  int, default: 3
+            """,
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,5 @@
-import os
 import textwrap
 from typing import List
-
-import pytest
 
 from argser import Opt, sub_command
 # noinspection PyProtectedMember
@@ -26,11 +23,6 @@ def test_cli():
     args.shell = 'bash'
     # run without errors:
     autocomplete(args)
-
-
-@pytest.fixture(autouse=True)
-def _ansi_color_disable():
-    os.environ['ANSI_COLORS_DISABLED'] = '1'
 
 
 class TestHelpFormatting:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -133,7 +133,7 @@ class TestHelpFormatting:
             v: int = Opt(action='count', default=0)
             v1: int = Opt(action='count', help='bar')
             v2: int = Opt(action='count', help="foo")
-            ap: List[str] = Opt(action='append')
+            ap: list = Opt(action='append')
 
         self.compare(
             Args,
@@ -145,7 +145,7 @@ class TestHelpFormatting:
                 -v          int, default: 0
                 --v1        int, default: None. bar
                 --v2        int, default: None. foo
-                --ap A      List[str], default: None
+                --ap A      list, default: None
             """,
         )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,11 @@
+import os
 import textwrap
 from typing import List
 
 from argser import Opt, sub_command
 # noinspection PyProtectedMember
 from argser.parser import _read_args, _make_parser
-from argser.utils import is_list_like_type, ColoredHelpFormatter, colors
+from argser.utils import is_list_like_type
 
 
 def test_is_list_typing():
@@ -26,6 +27,8 @@ def test_cli():
 
 
 def test_help():
+    os.environ['ANSI_COLORS_DISABLED'] = '1'  # disable colorization of help message
+
     class Base:
         bb: bool = Opt(default=True, help="foo bar")
 
@@ -50,14 +53,8 @@ def test_help():
 
         sub = sub_command(Sub, help='sub1 help')
 
-    class HelpFormatter(ColoredHelpFormatter):
-        header_color = colors.no
-        invoc_color = colors.no
-        type_color = colors.no
-        default_color = colors.no
-
     args_cls, args, sub_commands = _read_args(Args)
-    parser = _make_parser('root', args, sub_commands, formatter_class=HelpFormatter, prog='prog')
+    parser = _make_parser('root', args, sub_commands, prog='prog')
     help_msg = parser.format_help()
     print(help_msg)
     real_help = textwrap.dedent(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -65,7 +65,7 @@ def test_help():
 
         positional arguments:
             {sub}
-                sub                 str. sub1 help
+                sub                 sub1 help
 
         optional arguments:
             -h, --help              show this help message and exit


### PR DESCRIPTION
- [x] restructure Option class
- [x] add constructor attr
- [x] add simplified version of argument with help
- [x] some bug fixes
- [x] add docs and update readme