### PR TITLE
read factory function from Args class

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: tests
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   linting:
@@ -40,7 +40,7 @@ jobs:
           poetry install -E all
       - name: Test
         run: |
-          pip install pytest pytest-cov
+          pip install pytest pytest-cov pytest-sugar
           pytest --cov=argser --cov-report term-missing --cov-report xml
       - name: Upload coverage to Codecov
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Versions follow [Semantic Versioning](https://semver.org) (`<major>.<minor>.<pat
 **But**. Currently project is in alpha stage (`0.0.*`) and any changes can potentially break existing code.
 
 
+## Unpublished
+
+- read factory functions from Args class 
+
+
 ## 0.0.12
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ Versions follow [Semantic Versioning](https://semver.org) (`<major>.<minor>.<pat
 
 ## Unpublished
 
-- read factory functions from Args class 
+- rename Opt param ``constructor`` to ``factory``
+- read factory functions from Args class
 
 
 ## 0.0.12

--- a/argser/__init__.py
+++ b/argser/__init__.py
@@ -1,10 +1,12 @@
 __version__ = "0.0.13"
 
 from argser.consts import FALSE_VALUES, TRUE_VALUES
-from argser.display import stringify, print_args
+from argser.display import print_args, stringify
+from argser.exceptions import ArgserException
 from argser.fields import Arg, Opt
 from argser.parse_func import SubCommands, call
 from argser.parser import make_parser, parse_args, populate_holder, sub_command
+
 
 parse = parse_args
 Argument = Arg

--- a/argser/consts.py
+++ b/argser/consts.py
@@ -1,6 +1,8 @@
-from typing import TypeVar
+from typing import TypeVar, Union, Type
+
 
 Args = TypeVar('Args')
+ArgsObj = Union[Args, Type[Args]]
 
 TRUE_VALUES = {'1', 'true', 't', 'okay', 'ok', 'affirmative', 'yes', 'y', 'totally'}
 FALSE_VALUES = {'0', 'false', 'f', 'no', 'n', 'nope', 'nah'}

--- a/argser/display.py
+++ b/argser/display.py
@@ -11,7 +11,7 @@ from argser.utils import colors, vlen, args_to_dict
 def stringify(args: Args, shorten=False):
     pairs = []
     for key, value in args_to_dict(args).items():
-        if hasattr(value.__class__, SUB_COMMAND_MARK):
+        if hasattr(value, SUB_COMMAND_MARK):
             value = stringify(value, shorten)
         else:
             value = _format_value(value, shorten, fill=False)
@@ -25,7 +25,7 @@ def stringify(args: Args, shorten=False):
 def _get_table(args: Args):
     data = []
     for key, value in args_to_dict(args).items():
-        if hasattr(value.__class__, SUB_COMMAND_MARK):
+        if hasattr(value, SUB_COMMAND_MARK):
             sub_data = _get_table(value)
             data.extend([(f"{key}__{k}", v) for k, v in sub_data])
         else:
@@ -155,7 +155,7 @@ def make_tree(args: Args, shorten=False, fill=40, indent=''):
         field = colors.green(field)
         p = '└' if i == len(data) - 1 else '├'
 
-        if hasattr(value.__class__, SUB_COMMAND_MARK):
+        if hasattr(value, SUB_COMMAND_MARK):
             value = make_tree(value, shorten=shorten, fill=fill, indent=indent + '  ')
             parts.append(f"{indent}{p} {field} = {value}")
             continue

--- a/argser/exceptions.py
+++ b/argser/exceptions.py
@@ -1,0 +1,2 @@
+class ArgserException(Exception):
+    pass

--- a/argser/parser.py
+++ b/argser/parser.py
@@ -6,7 +6,7 @@ from functools import partial
 from types import FunctionType
 from typing import Any, List, Type, Tuple, Dict
 
-from argser.consts import Args, SUB_COMMAND_MARK
+from argser.consts import Args, ArgsObj, SUB_COMMAND_MARK
 from argser.display import print_args, stringify
 from argser.exceptions import ArgserException
 from argser.fields import Opt
@@ -59,7 +59,7 @@ def _extract_methods(args_cls: Type[Args]):
 
 
 def _set_factory_from_class_method(
-    option: Opt, methods: Dict[str, FunctionType], key: str
+    args: Args, option: Opt, methods: Dict[str, FunctionType], key: str
 ):
     if isinstance(option.factory, str):
         if option.factory not in methods:
@@ -70,19 +70,20 @@ def _set_factory_from_class_method(
     else:
         method = None
     if method:
-        option.factory = partial(method, None)
+        option.factory = partial(method, args)
 
 
 def _read_args(
-    args_cls: Type[Args],
+    args: Args,
     parser_name='root',
     override=False,
     bool_flag=True,
     prefix='--',
     repl=('_', '-'),
-) -> Tuple[Type[Args], List[Opt], Dict[str, tuple]]:
-    args = []
+) -> Tuple[Args, List[Opt], Dict[str, tuple]]:
+    options = []
     sub_commands = {}
+    args_cls = args.__class__
     ann = _collect_annotations(args_cls)
     fields = _get_fields(args_cls)
     methods = _extract_methods(args_cls)
@@ -93,7 +94,7 @@ def _read_args(
 
         if hasattr(value, SUB_COMMAND_MARK):
             sub_commands[key] = _read_args(
-                value.__class__, dest, bool_flag=bool_flag, prefix=prefix, repl=repl
+                value, dest, bool_flag=bool_flag, prefix=prefix, repl=repl
             )
             continue
         if isinstance(value, Opt):
@@ -124,7 +125,7 @@ def _read_args(
             )
 
         # read factory method
-        _set_factory_from_class_method(option, methods, key)
+        _set_factory_from_class_method(args, option, methods, key)
 
         # override params based on global params
         if override:
@@ -137,9 +138,9 @@ def _read_args(
 
         # update class attribute with populated Opt instance
         setattr(args_cls, key, option)
-        args.append(option)
+        options.append(option)
         logger.log(VERBOSE, option.__dict__)
-    return args_cls, args, sub_commands
+    return args, options, sub_commands
 
 
 def _join_names(*names: str):
@@ -181,9 +182,9 @@ def _make_parser(
 
     sub_parser = parser.add_subparsers(dest=_uwrap(name))
 
-    for sub_name, (args_cls, args, sub_p) in sub_commands.items():
-        p = getattr(args_cls, '__parser', None)
-        parser_kwargs = getattr(args_cls, '__kwargs', {})
+    for sub_name, (args_ins, args, sub_p) in sub_commands.items():
+        p = getattr(args_ins, '__parser', None)
+        parser_kwargs = getattr(args_ins, '__kwargs', {})
         parser_kwargs.setdefault('formatter_class', formatter_class)
 
         p = _make_parser(
@@ -219,14 +220,10 @@ def _set_values(
     for arg in args:
         setattr(res, arg.name, namespace.__dict__.get(arg.dest))
 
-    for name, (args_cls, args, sub_c) in sub_commands.items():
+    for name, (args_ins, args, sub_c) in sub_commands.items():
         # set values only if sub-command was chosen
         if getattr(namespace, _uwrap(parser_name)) == name:
             sub = getattr(res, name)
-            # Reinitialize instance of sub-command so that nullification of attribute
-            # would not touch original class and inner sub-commands. Mostly useful for
-            # tests.
-            sub = sub.__class__()
             setattr(res, name, sub)
             sub_parser_name = _join_names(parser_name, name)
             _set_values(sub_parser_name, sub, namespace, args, sub_c)
@@ -263,11 +260,21 @@ def _make_shortcuts(args: List[Opt]):
 
 def _make_shortcuts_sub_wise(args: List[Opt], sub_commands: dict):
     _make_shortcuts(args)
-    for name, (args_cls, args, sub_p) in sub_commands.items():
+    for name, (args_ins, args, sub_p) in sub_commands.items():
         _make_shortcuts_sub_wise(args, sub_p)
 
 
-def sub_command(args_cls: Type[Args], parser=None, **kwargs) -> Args:
+def _get_args_instance(args: ArgsObj):
+    if isinstance(args, type):
+        args = args()
+    if args.__class__.__str__ is object.__str__:
+        setattr(args.__class__, '__str__', stringify)
+    if args.__class__.__repr__ is object.__repr__:
+        setattr(args.__class__, '__repr__', stringify)
+    return args
+
+
+def sub_command(args_cls: ArgsObj, parser=None, **kwargs) -> Args:
     """
     Add sub-command to the parser.
 
@@ -283,12 +290,11 @@ def sub_command(args_cls: Type[Args], parser=None, **kwargs) -> Args:
     >>> args = parse_args(Data, 'sub -a 2')
     >>> assert args.sub.a == 2
     """
-    setattr(args_cls, '__str__', stringify)
-    setattr(args_cls, '__repr__', stringify)
-    setattr(args_cls, '__parser', parser)
-    setattr(args_cls, '__kwargs', kwargs)
-    setattr(args_cls, SUB_COMMAND_MARK, True)
-    return args_cls()
+    args_ins = _get_args_instance(args_cls)
+    setattr(args_ins, '__parser', parser)
+    setattr(args_ins, '__kwargs', kwargs)
+    setattr(args_ins, SUB_COMMAND_MARK, True)
+    return args_ins
 
 
 def _add_prefixed_key(source: dict, target: dict, prefix: str):
@@ -308,7 +314,7 @@ def _setup_argcomplete(parser, **kwargs):
 
 
 def make_parser(
-    args_cls: Type[Args],
+    args: ArgsObj,
     parser=None,
     make_shortcuts=True,
     bool_flag=True,
@@ -320,9 +326,10 @@ def make_parser(
     **kwargs,
 ):
     """
-    Create arguments parser based on :attr:`args_cls`.
+    Create arguments parser based on :attr:`args`.
 
-    :param args_cls: class with defined arguments
+    :param args: instance of some class with static attributes to be used as
+        ArgParser's options
     :param parser: predefined parser
     :param make_shortcuts: make short version of arguments: ``--abc -> -a``,
         ``--abc_def -> --ad``
@@ -343,33 +350,30 @@ def make_parser(
     :return: instance of ArgumentParser and tuple with options
         (main_options, sub_command_options)
     """
-
-    args_cls, args, sub_commands = _read_args(
-        args_cls, override=override, bool_flag=bool_flag, prefix=prefix, repl=repl
+    args_ins, options, sub_commands = _read_args(
+        args, override=override, bool_flag=bool_flag, prefix=prefix, repl=repl
     )
     if make_shortcuts:
-        _make_shortcuts_sub_wise(args, sub_commands)
+        _make_shortcuts_sub_wise(options, sub_commands)
     # setup parser
     parser_kwargs = parser_kwargs or {}
     _add_prefixed_key(kwargs, parser_kwargs, 'parser_')
     parser_kwargs.setdefault('formatter_class', ColoredHelpFormatter)
-    parser = _make_parser('root', args, sub_commands, parser=parser, **parser_kwargs)
+    parser = _make_parser('root', options, sub_commands, parser=parser, **parser_kwargs)
     # argcomplete
     argcomplete_kwargs = argcomplete_kwargs or {}
     _add_prefixed_key(kwargs, argcomplete_kwargs, 'argcomplete_')
     _setup_argcomplete(parser, **argcomplete_kwargs)
-    return parser, (args, sub_commands)
+    return parser, (options, sub_commands)
 
 
-def populate_holder(
-    parser: ArgumentParser, args_cls: Type[Args], options: tuple, args=None
-):
+def populate_holder(args_ins: Args, parser: ArgumentParser, options: tuple, args=None):
     """
     Parse provided string or command line and populate :attr:`args_cls`
     with parsed values.
 
+    :param args_ins: arguments holder
     :param parser: generated parser
-    :param args_cls: arguments holder
     :param options: tuple with root arguments and sub-command arguments
     :param args: string to parse or ``None``
     :return: instance of :attr:`args_cls` with populated fields.
@@ -379,15 +383,14 @@ def populate_holder(
     namespace = parser.parse_args(args)
     logger.log(VERBOSE, namespace)
 
-    result = sub_command(args_cls)
     args, sub_commands = options
-    _set_values('root', result, namespace, args, sub_commands)
-    setattr(result, '__namespace__', namespace)
-    return result
+    _set_values('root', args_ins, namespace, args, sub_commands)
+    setattr(args_ins, '__namespace__', namespace)
+    return args_ins
 
 
 def parse_args(
-    args_cls: Type[Args],
+    args_cls: ArgsObj,
     args=None,
     *,
     show=None,
@@ -401,7 +404,7 @@ def parse_args(
     Parse arguments from string or command line and return populated
     instance of `args_cls`.
 
-    :param args_cls: class with defined arguments
+    :param args_cls: class with defined arguments or instance of such class
     :param args: arguments to parse. Either string or list of strings or None
         (to read from sys.args)
     :param show:
@@ -428,8 +431,10 @@ def parse_args(
     >>> args = parse_args(Data, '-a 1 -b 2.2 --no-c')
     >>> assert args.a == 1 and args.b == 2.2 and args.c is False
     """
-    parser, options = make_parser(args_cls, **kwargs)
-    result = populate_holder(parser, args_cls, options, args)
+    args_ins = _get_args_instance(args_cls)
+
+    parser, options = make_parser(args_ins, **kwargs)
+    result = populate_holder(args_ins, parser, options, args)
 
     tabulate_kwargs = tabulate_kwargs or {}
     _add_prefixed_key(kwargs, tabulate_kwargs, 'tabulate_')

--- a/argser/utils.py
+++ b/argser/utils.py
@@ -54,7 +54,6 @@ class colors:
 
 
 def args_to_dict(args: Args) -> dict:
-    res = args.__dict__.copy()
-    if '__namespace__' in res:
-        del res['__namespace__']
-    return res
+    return {
+        key: value for key, value in args.__dict__.items() if not key.startswith('_')
+    }

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -162,28 +162,6 @@ argparse params
     >>> assert args.c == [1, 2]
 
 
-factories
----------
-
-.. doctest::
-
-    >>> from argser import Opt
-
-    >>> def make_a(a: str):
-    ...     return int(a) + 42
-
-    >>> def make_b(b: str):
-    ...     return b + '42'
-
-    >>> class Args:
-    ...     a: int = Opt(factory=make_a)
-    ...     b = 'default', make_b, "help message for be"
-
-    >>> args = parse_args(Args, '-a 2 -b "foo"')
-    >>> assert args.a == 44
-    >>> assert args.b == "foo42"
-
-
 Actions
 *******
 
@@ -430,6 +408,46 @@ After parsing each attribute of parsed class will be replaced with populated ins
     >>> assert Args.b.type is int
     >>> assert Args.b.help == "help for a"
     >>> assert args.b == 2
+
+
+Arguments factory
+*****************
+
+From callable:
+
+.. doctest::
+
+  >>> def read_a(value: str):
+  ...     return int(value) + 1
+
+  >>> class Args:
+  ...     a = Opt(default=1, factory=read_a)
+
+  >>> parse_args(Args, '-a 2').a
+  3
+
+
+From method:
+
+.. doctest::
+
+  >>> class Args:
+  ...     a = 1
+  ...     def read_a(self, value: str):
+  ...         return int(value) + 1
+
+  >>> parse_args(Args, '-a 2').a
+  3
+
+From method with different name:
+
+  >>> class Args:
+  ...     a = Opt(default=1, factory='get_a')
+  ...     def get_a(self, value: str):
+  ...         return int(value) + 1
+
+  >>> parse_args(Args, '-a 2').a
+  3
 
 
 Auto completion

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -162,8 +162,8 @@ argparse params
     >>> assert args.c == [1, 2]
 
 
-constructors
-------------
+factories
+---------
 
 .. doctest::
 
@@ -176,7 +176,7 @@ constructors
     ...     return b + '42'
 
     >>> class Args:
-    ...     a: int = Opt(constructor=make_a)
+    ...     a: int = Opt(factory=make_a)
     ...     b = 'default', make_b, "help message for be"
 
     >>> args = parse_args(Args, '-a 2 -b "foo"')

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -4,6 +4,7 @@ from typing import List
 import pytest
 
 from argser import Opt
+from argser.exceptions import ArgserException
 
 
 def test_opt_replace():
@@ -78,149 +79,149 @@ class TestGuessType:
         o = Opt()
         typ, nargs = o.guess_type_and_nargs(annotation=None)
         assert o.type is typ is str
-        assert o.constructor is str
+        assert o.factory is str
         assert o.nargs is nargs is None
 
         o = Opt()
         typ, nargs = o.guess_type_and_nargs(annotation=int)
         assert o.type is typ is int
-        assert o.constructor is int
+        assert o.factory is int
         assert o.nargs is nargs is None
 
         o = Opt()
         typ, nargs = o.guess_type_and_nargs(annotation=List[float])
         assert o.type == List[float]
-        assert o.constructor is typ is float
+        assert o.factory is typ is float
         assert o.nargs == nargs == '*'
 
     def test_with_type(self):
         o = Opt(type=int)
         o.guess_type_and_nargs(annotation=None)
         assert o.type is int
-        assert o.constructor is int
+        assert o.factory is int
         assert o.nargs is None
 
         o = Opt(type=List[int])
         o.guess_type_and_nargs(annotation=None)
         assert o.type is List[int]
-        assert o.constructor is int
+        assert o.factory is int
         assert o.nargs == '*'
 
         o = Opt(type=List[int])
         o.guess_type_and_nargs(annotation=int)  # try override type with annotation
         assert o.type is List[int]  # but fail miserably
-        assert o.constructor is int
+        assert o.factory is int
         assert o.nargs is None
 
     def test_with_default(self):
         o = Opt(default=1)
         o.guess_type_and_nargs(annotation=None)
         assert o.type is int
-        assert o.constructor is int
+        assert o.factory is int
         assert o.nargs is None
 
         o = Opt(default=1)
         o.guess_type_and_nargs(annotation=float)
         assert o.type is float
-        assert o.constructor is float
+        assert o.factory is float
         assert o.nargs is None
 
         o = Opt(default=[])
         o.guess_type_and_nargs(annotation=None)
         assert o.type == List[str]
-        assert o.constructor is str
+        assert o.factory is str
         assert o.nargs == '*'
 
         o = Opt(default=[])
         o.guess_type_and_nargs(annotation=List[bool])
         assert o.type == List[bool]
-        assert o.constructor is bool
+        assert o.factory is bool
         assert o.nargs == '*'
 
         o = Opt(default=[1.1])
         o.guess_type_and_nargs(annotation=None)
         assert o.type == List[float]
-        assert o.constructor is float
+        assert o.factory is float
         assert o.nargs == '+'
 
-    def test_with_constructor(self):
-        o = Opt(constructor=lambda x: x.upper())
+    def test_with_factory(self):
+        o = Opt(factory=lambda x: x.upper())
         o.guess_type_and_nargs(annotation=None)
         assert o.type is str
-        assert o.constructor('a') == 'A'
+        assert o.factory('a') == 'A'
         assert o.nargs is None
 
-        # user error: type and constructor result mismatch
-        o = Opt(constructor=lambda x: x.upper())
+        # user error: type and factory result mismatch
+        o = Opt(factory=lambda x: x.upper())
         o.guess_type_and_nargs(annotation=int)
         assert o.type is int
-        assert o.constructor('a') == 'A'
+        assert o.factory('a') == 'A'
         assert o.nargs is None
 
-        o = Opt(constructor=lambda x: float(x) + 2.2)
+        o = Opt(factory=lambda x: float(x) + 2.2)
         o.guess_type_and_nargs(annotation=float)
         assert o.type is float
-        assert o.constructor('1.1') == pytest.approx(3.3)
+        assert o.factory('1.1') == pytest.approx(3.3)
         assert o.nargs is None
 
-        o = Opt(constructor=lambda x: list(map(int, x)))
+        o = Opt(factory=lambda x: list(map(int, x)))
         o.guess_type_and_nargs(annotation=List[int])
         assert o.type is List[int]
-        assert o.constructor('123') == [1, 2, 3]
+        assert o.factory('123') == [1, 2, 3]
         assert o.nargs == '*'
 
     def test_with_nargs(self):
         o = Opt(nargs='?')
         o.guess_type_and_nargs(annotation=None)
         assert o.type is str
-        assert o.constructor is str
+        assert o.factory is str
         assert o.nargs == '?'
 
         o = Opt(nargs='*')
         o.guess_type_and_nargs(annotation=None)
         assert o.type == List[str]
-        assert o.constructor is str
+        assert o.factory is str
         assert o.nargs == '*'
 
         o = Opt(nargs='+')
         o.guess_type_and_nargs(annotation=None)
         assert o.type == List[str]
-        assert o.constructor is str
+        assert o.factory is str
         assert o.nargs == '+'
 
         o = Opt(nargs=2)
         o.guess_type_and_nargs(annotation=None)
         assert o.type == List[str]
-        assert o.constructor is str
+        assert o.factory is str
         assert o.nargs == 2
 
     def test_complex(self):
-        o = Opt(type=str, constructor=lambda x: x.upper())
+        o = Opt(type=str, factory=lambda x: x.upper())
         o.guess_type_and_nargs(annotation=None)
         assert o.type is str
-        assert o.constructor('a') == 'A'
+        assert o.factory('a') == 'A'
         assert o.nargs is None
 
-        o = Opt(default=1.1, constructor=lambda x: float(x) + 1)
+        o = Opt(default=1.1, factory=lambda x: float(x) + 1)
         o.guess_type_and_nargs(annotation=None)
         assert o.type is float
-        assert o.constructor('1.1') == pytest.approx(2.1)
+        assert o.factory('1.1') == pytest.approx(2.1)
         assert o.nargs is None
 
-        o = Opt('o', type=bool, constructor=lambda x: x == 'foo')
+        o = Opt('o', type=bool, factory=lambda x: x == 'foo')
         o.guess_type_and_nargs(annotation=None)
         assert o.type is bool
-        assert o.constructor('foo') is True
+        assert o.factory('foo') is True
         assert o.nargs is None
         p = ArgumentParser()
         o.inject(p)
         assert p.parse_args('-o foo'.split()).o is True
         assert p.parse_args('-o bar'.split()).o is False
 
-        o = Opt('o', default=[1, 2], constructor=lambda x: int(x) + 1)
+        o = Opt('o', default=[1, 2], factory=lambda x: int(x) + 1)
         o.guess_type_and_nargs(annotation=None)
         assert o.type == List[int]
-        assert o.constructor('1') == 2
+        assert o.factory('1') == 2
         assert o.nargs == '+'
         p = ArgumentParser()
         o.inject(p)
@@ -230,28 +231,28 @@ class TestGuessType:
     def test_list_from_single_value(self):
         o = Opt(
             'o',
-            constructor=lambda x: [int(e) + 1 for e in list(x)],
+            factory=lambda x: [int(e) + 1 for e in list(x)],
             nargs='?',
             default=[-1],
         )
         o.guess_type_and_nargs(annotation=None)
         assert o.type == List[int]
-        assert o.constructor('123') == [2, 3, 4]
+        assert o.factory('123') == [2, 3, 4]
         assert o.nargs == '?'
         p = ArgumentParser()
         o.inject(p)
         assert p.parse_args('-o 123'.split()).o == [2, 3, 4]
 
 
-def test_pick_constructor():
+def test_pick_factory():
     def foo():
         pass
 
-    assert Opt()._pick_constructor(1, 2, foo) is foo
-    assert Opt()._pick_constructor(1, foo, 2) is foo
-    assert Opt()._pick_constructor(None) is None
-    with pytest.raises(ValueError):
-        Opt()._pick_constructor(1, 2, 3)
+    assert Opt()._pick_factory(1, 2, foo) is foo
+    assert Opt()._pick_factory(1, foo, 2) is foo
+    assert Opt()._pick_factory(None) is None
+    with pytest.raises(ArgserException):
+        Opt()._pick_factory(1, 2, 3)
 
 
 def test_pretty_format():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -6,6 +6,7 @@ import pytest
 
 import argser
 from argser import Arg, Opt, parse_args, sub_command
+from argser.exceptions import ArgserException
 from argser.parser import (
     _make_shortcuts_sub_wise as make_shortcuts,
     _read_args as read_args,
@@ -280,15 +281,15 @@ class TestList:
     def test_types(self):
         args_cls, (a, b, c, d, e), sub_commands = read_args(self.args_cls)
         assert a.type is list  # because of annotation
-        assert a.constructor is str
+        assert a.factory is str
         assert b.type == List  # ^ same
-        assert b.constructor is str
+        assert b.factory is str
         assert c.type == List[int]
-        assert c.constructor is int
+        assert c.factory is int
         assert d.type == List[bool]
-        assert d.constructor is bool
+        assert d.factory is bool
         assert e.type == List[float]
-        assert e.constructor is float
+        assert e.factory is float
 
 
 def test_non_standard_type():
@@ -509,29 +510,13 @@ def test_prefix():
     assert args.bbb == 42
 
 
-def test_constructor():
-    class Args:
-        a: List[int] = Opt(
-            constructor=lambda x: [int(e) + 1 for e in list(x)], nargs='?', default=[-1]
-        )
-        b: int = Opt(constructor=lambda x: int(x) + 2)
-
-    args = parse_args(Args, '')
-    assert args.a == [-1]
-    assert args.b is None
-
-    args = parse_args(Args, '-a 123 -b 5')
-    assert args.a == [2, 3, 4]
-    assert args.b == 7
-
-
 def test_quick_help():
     class Args:
         # default, help
         a = 1, "help for a"
         # with annotation parenthesis are required
         b: str = (None, "help for b")
-        # default, constructor, help
+        # default, factory, help
         c: float = (5.0, lambda x: float(x) * 2, "help for b")
 
     args = parse_args(Args, '')
@@ -547,13 +532,14 @@ def test_quick_help():
     class Args:
         e = ('foo', str, "help", "some trash no one asked for")
 
-    with pytest.raises(ValueError) as context:
+    with pytest.raises(ArgserException) as context:
         parse_args(Args, '')
-    assert '(default, help) or (default, constructor, help)' in str(context.value)
+    assert '(default, help) or (default, factory, help)' in str(context.value)
 
 
 def test_sub_cmd_with_same_arguments():
-    # use factory because parse_args will remove static sub-cmd attributes from inner classed
+    # use factory because parse_args will remove static sub-cmd attributes from
+    # inner classed
     class Args:
         a = 1
         b = 2
@@ -712,7 +698,7 @@ def test_updated_arguments_on_holder():
 
     assert isinstance(Args.dd, Opt)
     assert Args.dd.type == List[int]
-    assert Args.dd.constructor is int
+    assert Args.dd.factory is int
     assert Args.dd.default == [1]
     assert Args.dd.help == 'help dd'
     assert args.dd == [3]
@@ -726,3 +712,100 @@ def test_updated_arguments_on_holder():
     assert Args.f.type is str
     assert Args.f.default is None
     assert args.f == 'foo'
+
+
+class TestFactory:
+    def test_simple(self):
+        def make_cls():
+            class Args:
+                a = 1
+
+                def read_a(self, x: str):
+                    return int(x) + 1
+
+            return Args
+
+        args = parse_args(make_cls(), '')
+        assert args.a == 1
+
+        args = parse_args(make_cls(), '-a 5')
+        assert args.a == 6
+
+    def test_string(self):
+        def make_cls():
+            class Args:
+                a = Opt(default=1, factory='read_b')
+
+                def read_b(self, x: str):
+                    return int(x) + 1
+
+            return Args
+
+        args = parse_args(make_cls(), '')
+        assert args.a == 1
+
+        args = parse_args(make_cls(), '-a 5')
+        assert args.a == 6
+
+    def test_invalid_string(self):
+        class Args:
+            a = Opt(default=1, factory='read_A')
+
+            def read_a(self, x: str):
+                return int(x) + 1
+
+        with pytest.raises(ArgserException):
+            parse_args(Args, '')
+
+    def test_function(self):
+        def make_cls():
+            def read_a(x: str):
+                return int(x) + 1
+
+            class Args:
+                a = Opt(default=1, factory=read_a)
+
+            return Args
+
+        args = parse_args(make_cls(), '')
+        assert args.a == 1
+
+        args = parse_args(make_cls(), '-a 5')
+        assert args.a == 6
+
+    def test_lambdas(self):
+        class Args:
+            a: List[int] = Opt(
+                factory=lambda x: [int(e) + 1 for e in list(x)], nargs='?', default=[-1]
+            )
+            b: int = Opt(factory=lambda x: int(x) + 2)
+
+        args = parse_args(Args, '')
+        assert args.a == [-1]
+        assert args.b is None
+
+        args = parse_args(Args, '-a 123 -b 5')
+        assert args.a == [2, 3, 4]
+        assert args.b == 7
+
+
+@pytest.mark.xfail
+class TestInstanceOfArgs:
+    def test_factory(self):
+        class Args:
+            a = 1
+
+            def read_a(self, x: str):
+                assert self  # should be available
+                return int(x) + 1
+
+        parse_args(Args, '-a 2')
+
+    def test_instance(self):
+        class Args:
+            a = 1
+
+        original = Args()
+        args = parse_args(original, '-a 2')
+        assert args is original
+        assert original.a == 2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,9 +26,9 @@ def test_cli():
 
 
 class TestHelpFormatting:
-    def compare(self, args_cls, help_text: str):
-        args_cls, args, sub_commands = _read_args(args_cls)
-        parser = _make_parser('root', args, sub_commands, prog='prog')
+    def compare(self, args, help_text: str):
+        args, options, sub_commands = _read_args(args)
+        parser = _make_parser('root', options, sub_commands, prog='prog')
         help_msg = parser.format_help()
         print(help_msg)
         real_help = textwrap.dedent(help_text)
@@ -44,7 +44,7 @@ class TestHelpFormatting:
             sub = sub_command(Sub, help='sub help')
 
         self.compare(
-            Args,
+            Args(),
             """
             usage: prog [-h] a {sub} ...
 
@@ -68,7 +68,7 @@ class TestHelpFormatting:
         # sometime python3.6 behave strangely and miss inner type in List
         try:
             self.compare(
-                Args,
+                Args(),
                 """
                 usage: prog [-h] [--l0 [L [L ...]]] [--l1 L [L ...]] [--l2 [L [L ...]]] [--ap A]
 
@@ -82,7 +82,7 @@ class TestHelpFormatting:
             )
         except AssertionError:
             self.compare(
-                Args,
+                Args(),
                 """
                 usage: prog [-h] [--l0 [L [L ...]]] [--l1 L [L ...]] [--l2 [L [L ...]]] [--ap A]
 
@@ -104,7 +104,7 @@ class TestHelpFormatting:
             b1 = True
 
         self.compare(
-            Args,
+            Args(),
             """
             usage: prog [-h] [-b] [--no-b] [--b1] [--no-b1] [--bb] [--no-bb]
 
@@ -130,7 +130,7 @@ class TestHelpFormatting:
             sub = sub_command(Sub, help='sub1 help')
 
         self.compare(
-            Args,
+            Args(),
             """
             usage: prog [-h] [-a A] {sub} ...
 
@@ -152,7 +152,7 @@ class TestHelpFormatting:
             ap: list = Opt(action='append')
 
         self.compare(
-            Args,
+            Args(),
             """
             usage: prog [-h] [-v] [--v1] [--v2] [--ap A]
 
@@ -175,7 +175,7 @@ class TestHelpFormatting:
             foo_bar_baaaaaaaaz = 3
 
         self.compare(
-            Args,
+            Args(),
             """
             usage: prog [-h] [-b] [--no-b] [--b1] [--no-b1] [-f F] [-c N] [--dddd D] [--foo-bar-baaaaaaaaz F]
 


### PR DESCRIPTION
- [x] rename constructor to factory
- [x] read factory function from Args class by string
- [x] ... from default name (eg `def read_OPTION(value: str)...`)
- [x] allow to parse args based on instance of `Args` class and populate `self` in factory methods
- [x] docs